### PR TITLE
Group suggestions on empty group page

### DIFF
--- a/agir/front/components/genericComponents/Onboarding.js
+++ b/agir/front/components/genericComponents/Onboarding.js
@@ -19,6 +19,19 @@ const ONBOARDING_TYPE = {
     createLabel: "Créer un événement",
     createRoute: "createEvent",
   },
+  group__suggestions: {
+    title: "Rejoignez une équipe proche de chez vous",
+    body:
+      "Les groupes de soutien permettent aux militants de s’organiser dans leur quartier ou dans leur ville. Rejoignez un groupe, agissez sur le terrain et organisez des moments de réflexions politiques !",
+    mapIframe: "groupsMap",
+  },
+  group__creation: {
+    title: "Ou bien créez votre équipe !",
+    body:
+      "Créez votre équipe en quelques clics, et commencez dès aujourd’hui à organiser des actions pour soutenir la candidature de Jean-Luc Mélenchon. Besoin d’inspiration pour animer votre équipe ? Voici quelques pistes.",
+    createLabel: "Créer une équipe de soutien",
+    createRoute: "createGroup",
+  },
   group__nsp: {
     img: onboardingActionImage,
     title: "Rejoignez ou organisez une équipe de soutien",
@@ -51,6 +64,15 @@ const ONBOARDING_TYPE = {
     createRoute: "createGroup",
   },
 };
+
+const Map = styled.iframe`
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 338px;
+  border: none;
+  overflow: hidden;
+`;
 
 const StyledBlock = styled.section`
   display: flex;
@@ -125,13 +147,17 @@ const Onboarding = (props) => {
     body,
     mapLabel,
     mapRoute,
+    mapIframe,
     createLabel,
     createRoute,
   } = ONBOARDING_TYPE[type];
   return (
     <StyledBlock>
       <header>
-        <div style={{ backgroundImage: `url(${img})` }} />
+        {img ? <div style={{ backgroundImage: `url(${img})` }} /> : null}
+        {mapIframe && routes[mapIframe] ? (
+          <Map src={routes[mapIframe]} />
+        ) : null}
         <h3>{title}</h3>
       </header>
       <article>

--- a/agir/front/views.py
+++ b/agir/front/views.py
@@ -210,15 +210,17 @@ class MyGroupsView(SoftLoginRequiredMixin, ReactListView):
             .order_by("-membership_type", "name")
         )
         if person_groups.count() == 0 and person.coordinates is not None:
-            person_groups = (
-                SupportGroup.objects.active()
-                .annotate(distance=Distance("coordinates", person.coordinates))
-                .order_by("distance")[:10]
-            )
+            person_groups = SupportGroup.objects.active()
+            if person.is_2022_only:
+                person_groups = person_groups.is_2022()
+            person_groups = person_groups.annotate(
+                distance=Distance("coordinates", person.coordinates)
+            ).order_by("distance")[:3]
             for group in person_groups:
                 person_groups.membership = None
 
         return person_groups
+
 
 class EventMapView(SoftLoginRequiredMixin, ReactBaseView):
     bundle_name = "carte/page__eventMap"

--- a/agir/groups/components/groupsPage/GroupsPage.js
+++ b/agir/groups/components/groupsPage/GroupsPage.js
@@ -50,7 +50,7 @@ const TopBar = styled.div`
 `;
 
 const GroupList = styled.article`
-  margin-bottom: 60px;
+  margin-bottom: 2rem;
 
   @media (max-width: ${style.collapse}px) {
     padding: 0 16px;
@@ -78,6 +78,11 @@ const GroupsPage = ({ data }) => {
     [data]
   );
 
+  const hasOwnGroups = React.useMemo(
+    () => groups.some((group) => group.isMember),
+    [groups]
+  );
+
   return (
     <Layout active="groups" smallBackgroundColor={style.black25}>
       <TopBar>
@@ -101,9 +106,10 @@ const GroupsPage = ({ data }) => {
           ) : null}
         </div>
       </TopBar>
-      {groups.length === 0 ? (
-        <Onboarding type="group__action" routes={routes} />
-      ) : (
+      {!hasOwnGroups ? (
+        <Onboarding type="group__suggestions" routes={routes} />
+      ) : null}
+      {groups.length > 0 && (
         <GroupList>
           {groups.map((group) => (
             <GroupCard
@@ -117,6 +123,9 @@ const GroupsPage = ({ data }) => {
           ))}
         </GroupList>
       )}
+      {!hasOwnGroups ? (
+        <Onboarding type="group__creation" routes={routes} />
+      ) : null}
     </Layout>
   );
 };


### PR DESCRIPTION
Ajouter des suggestions de groupes proches, sur la page mes groupes, lorsque l'utilisateur n'appartient à aucun groupe.
- Mise à jour de la view pour récuperer des suggestions lorsque la requête des groupes de l'utilisateur ne renvoie aucun résultat
- Ajout de nouvelles configuration de Onboarding et ajout de la possibilité d'ajouter une carte au lieu de l'image
- Mise à jour du composant GroupsPage