### PR TITLE
Gdp/limit nsp group creation to 1 per referent

### DIFF
--- a/agir/groups/models.py
+++ b/agir/groups/models.py
@@ -106,8 +106,16 @@ class SupportGroup(
         " journaux locaux, auto-organisation, etc…).",
         TYPE_PROFESSIONAL: "Les groupes d’action professionnels rassemblent des insoumis⋅es qui"
         " souhaitent agir au sein de leur entreprise ou de leur lieu d’étude.",
-        TYPE_2022: "Les équipes de soutien « Nous Sommes Pour ! » peuvent être rejoints par toutes les personnes "
+        TYPE_2022: "Les équipes de soutien « Nous Sommes Pour ! » peuvent être rejointes par toutes les personnes "
         "ayant parainné la candidature de Jean-Luc Mélenchon.",
+    }
+
+    TYPE_DISABLED_DESCRIPTION = {
+        TYPE_LOCAL_GROUP: "",
+        TYPE_THEMATIC: "",
+        TYPE_FUNCTIONAL: "",
+        TYPE_PROFESSIONAL: "",
+        TYPE_2022: "✅ Vous animez déjà une équipe de soutien",
     }
 
     objects = SupportGroupQuerySet.as_manager()

--- a/agir/groups/views/management_views.py
+++ b/agir/groups/views/management_views.py
@@ -198,6 +198,8 @@ class CreateSupportGroupView(HardLoginRequiredMixin, TemplateView):
         )
 
         types = []
+        disabled_types = []
+
         if person.is_insoumise:
             types.extend(SupportGroup.TYPE_LFI_CHOICES)
 
@@ -211,7 +213,10 @@ class CreateSupportGroupView(HardLoginRequiredMixin, TemplateView):
                 )
                 .exists()
             )
-            if not is_2022_group_manager:
+
+            if is_2022_group_manager:
+                disabled_types.extend(SupportGroup.TYPE_NSP_CHOICES)
+            else:
                 types.extend(SupportGroup.TYPE_NSP_CHOICES)
 
         types = [
@@ -219,8 +224,19 @@ class CreateSupportGroupView(HardLoginRequiredMixin, TemplateView):
                 "id": id,
                 "label": label,
                 "description": SupportGroup.TYPE_DESCRIPTION[id],
+                "disabledDescription": SupportGroup.TYPE_DISABLED_DESCRIPTION[id],
+                "disabled": False,
             }
             for id, label in types
+        ] + [
+            {
+                "id": id,
+                "label": label,
+                "description": SupportGroup.TYPE_DESCRIPTION[id],
+                "disabledDescription": SupportGroup.TYPE_DISABLED_DESCRIPTION[id],
+                "disabled": True,
+            }
+            for id, label in disabled_types
         ]
 
         subtypes = [

--- a/agir/groups/views/management_views.py
+++ b/agir/groups/views/management_views.py
@@ -202,7 +202,17 @@ class CreateSupportGroupView(HardLoginRequiredMixin, TemplateView):
             types.extend(SupportGroup.TYPE_LFI_CHOICES)
 
         if person.is_2022:
-            types.extend(SupportGroup.TYPE_NSP_CHOICES)
+            is_2022_group_manager = (
+                SupportGroup.objects.active()
+                .filter(
+                    type__in=[choice[0] for choice in SupportGroup.TYPE_NSP_CHOICES],
+                    memberships__person=person,
+                    memberships__membership_type__gte=Membership.MEMBERSHIP_TYPE_MANAGER,
+                )
+                .exists()
+            )
+            if not is_2022_group_manager:
+                types.extend(SupportGroup.TYPE_NSP_CHOICES)
 
         types = [
             {

--- a/agir/lib/components/creationForms/createGroupForm.js
+++ b/agir/lib/components/creationForms/createGroupForm.js
@@ -182,12 +182,24 @@ class GroupTypeStep extends FormStep {
               <button
                 className={`btn btn-default ${
                   fields.type === type.id ? "active" : ""
-                }`}
-                style={{ whiteSpace: "normal" }}
-                onClick={this.setType(type.id)}
+                }`.trim()}
+                style={{
+                  whiteSpace: "normal",
+                  backgroundColor: type.disabled ? "transparent" : undefined,
+                  opacity: type.disabled ? ".5" : undefined,
+                }}
+                onClick={type.disabled ? undefined : this.setType(type.id)}
+                disabled={type.disabled}
               >
                 <strong>{type.label}</strong>
                 {type.description}
+                {type.disabled ? (
+                  <>
+                    <br />
+                    <br />
+                    {type.disabledDescription}
+                  </>
+                ) : null}
               </button>
             </div>
           ))}


### PR DESCRIPTION
- désactiver le type de groupe NSP sur la page de création de groupe si l'utilisateur est déjà animateur ou organisateur d'un groupe NSP
- filtrer les options animateur/organisateur sur l'admin de groupe (pour les groupes NSP) : afficher uniquement les membres du groupe qui ne sont pas déjà animateurs/organisateurs d'un autre groupe NSP