### PR TITLE
feat(lib): create middleware and decorator to force removing of Vary:

### DIFF
--- a/agir/api/settings.py
+++ b/agir/api/settings.py
@@ -175,6 +175,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "agir.lib.middleware.NoVaryCookieMiddleWare",
     "agir.lib.middleware.TurbolinksMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -548,7 +549,9 @@ if not DEBUG:
 # CACHING
 CACHES = {
     "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
+        "BACKEND": "django_redis.cache.RedisCache"
+        if not DEBUG
+        else "django.core.cache.backends.dummy.DummyCache",
         "LOCATION": os.environ.get("CACHING_REDIS_URL", "redis://localhost?db=0"),
         "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
         "KEY_PREFIX": "caching_",

--- a/agir/carte/views.py
+++ b/agir/carte/views.py
@@ -5,6 +5,7 @@ import django_filters
 from django.contrib.gis.geos import Polygon
 from django.db.models import Q, Count
 from django.http import QueryDict, Http404
+from django.utils.decorators import method_decorator
 from django.utils.html import mark_safe
 from django.utils.timezone import now
 from django.utils.translation import ugettext as _
@@ -22,6 +23,7 @@ from . import serializers
 from ..events.filters import EventFilter
 from ..events.models import Event, EventSubtype
 from ..groups.models import SupportGroup, SupportGroupSubtype
+from ..lib.decorators import dont_vary_on_cookie
 from ..lib.filters import FixedModelMultipleChoiceFilter
 
 
@@ -87,25 +89,18 @@ class EventsView(ListAPIView):
     serializer_class = serializers.MapEventSerializer
     filter_backends = (BBoxFilterBackend, DjangoFilterBackend)
     filterset_class = EventFilter
-    authentication_classes = [SessionAuthentication]
 
     def get_queryset(self):
-        qs = Event.objects.all()
-        if self.request.user is None or not self.request.user.has_perms(
-            "view_hidden_event"
-        ):
-            qs = qs.listed()
+        qs = Event.objects.listed()
 
-        if (
-            self.request.user.is_authenticated
-            and hasattr(self.request.user, "person")
-            and self.request.user.person.is_2022_only
-        ):
+        if self.request.GET.get("var") == "nsp_only":
             qs = qs.is_2022()
 
         return qs.filter(coordinates__isnull=False).select_related("subtype")
 
-    @cache.cache_control(max_age=300, public=True)
+    @method_decorator(cache.cache_page(300))
+    @method_decorator(dont_vary_on_cookie)
+    @cache.cache_control(public=True)
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -127,23 +122,20 @@ class GroupsView(ListAPIView):
     serializer_class = serializers.MapGroupSerializer
     filter_backends = (BBoxFilterBackend, DjangoFilterBackend)
     filterset_class = GroupFilterSet
-    queryset = (
-        SupportGroup.objects.active()
-        .filter(coordinates__isnull=False)
-        .prefetch_related("subtypes")
-    )
 
-    @cache.cache_control(max_age=300, public=True)
+    @method_decorator(cache.cache_page(300))
+    @method_decorator(dont_vary_on_cookie)
+    @cache.cache_control(public=True)
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self):
-        qs = SupportGroup.objects.active()
-        if (
-            self.request.user.is_authenticated
-            and hasattr(self.request.user, "person")
-            and self.request.user.person.is_2022_only
-        ):
+        qs = (
+            SupportGroup.objects.active()
+            .filter(coordinates__isnull=False)
+            .prefetch_related("subtypes")
+        )
+        if self.request.GET.get("var") == "nsp_only":
             qs = qs.is_2022()
 
         return (

--- a/agir/lib/decorators.py
+++ b/agir/lib/decorators.py
@@ -1,0 +1,17 @@
+from functools import wraps
+
+
+def dont_vary_on_cookie(func):
+    """
+    Used with NoVaryCookieMiddleWare
+    :param func:
+    :return:
+    """
+
+    @wraps(func)
+    def inner_func(*args, **kwargs):
+        response = func(*args, **kwargs)
+        response.dont_vary_on_cookie = True
+        return response
+
+    return inner_func

--- a/agir/lib/middleware.py
+++ b/agir/lib/middleware.py
@@ -1,3 +1,4 @@
+import re
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -13,5 +14,39 @@ class TurbolinksMiddleware:
 
         location = urljoin(settings.FRONT_DOMAIN, urlquote(request.path))
         response["Turbolinks-Location"] = location
+
+        return response
+
+
+class NoVaryCookieMiddleWare:
+    cc_delim_re = re.compile(r"\s*,\s*")
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        if (
+            not hasattr(response, "dont_vary_on_cookie")
+            or not response.dont_vary_on_cookie
+        ):
+            return response
+
+        if response.has_header("Vary"):
+            vary_header = self.cc_delim_re.split(response["Vary"])
+        else:
+            # This response has no vary header, so don't change anything
+            return response
+
+        new_header = []
+        for vary in vary_header:
+            print(vary)
+            if not vary.lower() == "cookie":
+                new_header.append(vary)
+        if len(new_header) > 0:
+            response["Vary"] = ", ".join(new_header)
+        else:
+            del response["Vary"]
 
         return response


### PR DESCRIPTION
Cookie

* dont_vary_on_cookie decorator ads value on response
* NoVaryCookieMiddleWare checks this value and remove Vary: Cookie if
told so

NoVaryCookie MUST be set after SessionMiddleWare and other django
middlewares which add by default Vary: Cookie