### PR TITLE
fix: add 'meta' field to activity serializer

### DIFF
--- a/agir/activity/serializers.py
+++ b/agir/activity/serializers.py
@@ -47,6 +47,7 @@ class ActivitySerializer(FlexibleFieldsMixin, serializers.ModelSerializer):
             "supportGroup",
             "individual",
             "status",
+            "meta",
         ]
 
 


### PR DESCRIPTION
Ajout du champs `meta` au serializer des activités