### PR TITLE
Mark announcement as read

### DIFF
--- a/agir/front/components/dashboardComponents/Announcements.js
+++ b/agir/front/components/dashboardComponents/Announcements.js
@@ -1,11 +1,15 @@
 import { animated, useSpring } from "react-spring";
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect } from "react";
 import SwiperCore, { Pagination, A11y } from "swiper";
 import { Swiper, SwiperSlide } from "swiper/react";
 import styled from "styled-components";
 
-import { useSelector } from "@agir/front/globalContext/GlobalContext";
+import {
+  useDispatch,
+  useSelector,
+} from "@agir/front/globalContext/GlobalContext";
+import { setAnnouncementsAsRead } from "@agir/front/globalContext/actions";
 import { getAnnouncements } from "@agir/front/globalContext/reducers";
 
 import Announcement from "@agir/front/genericComponents/Announcement";
@@ -108,7 +112,19 @@ BannerAnnouncements.propTypes = SidebarAnnouncements.propTypes = {
 
 const Announcements = (props) => {
   const { displayType } = props;
+
+  const dispatch = useDispatch();
   const announcements = useSelector(getAnnouncements);
+
+  useEffect(() => {
+    if (!Array.isArray(announcements)) {
+      return;
+    }
+    const ids = announcements
+      .map((announcement) => announcement.activityId)
+      .filter(Boolean);
+    ids.length > 0 && dispatch(setAnnouncementsAsRead(ids));
+  }, [dispatch, announcements]);
 
   return displayType === "sidebar" ? (
     <SidebarAnnouncements announcements={announcements} />

--- a/agir/front/components/globalContext/actionTypes.json
+++ b/agir/front/components/globalContext/actionTypes.json
@@ -6,5 +6,7 @@
   "SET_ACTIVITY_AS_READ_ACTION": "setActivityAsRead",
   "SET_ALL_ACTIVITIES_AS_READ_ACTION": "setAllActivitiesAsRead",
 
-  "DISMISS_REQUIRED_ACTION_ACTIVITY_ACTION": "dismissRequiredActionActivity"
+  "DISMISS_REQUIRED_ACTION_ACTIVITY_ACTION": "dismissRequiredActionActivity",
+
+  "SET_ANNOUNCEMENTS_AS_READ_ACTION": "setAllActivitiesAsRead"
 }

--- a/agir/front/components/globalContext/actions.js
+++ b/agir/front/components/globalContext/actions.js
@@ -65,6 +65,19 @@ export const dismissRequiredActionActivity = (id) => async (dispatch) => {
     console.log(e);
   }
 };
+
+export const setAnnouncementsAsRead = (ids = []) => async (dispatch) => {
+  try {
+    const success = await setActivitiesAsRead(ids);
+    success &&
+      dispatch({
+        type: ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION,
+      });
+  } catch (e) {
+    console.log(e);
+  }
+};
+
 const createDispatch = (dispatchFunction) => (action) => {
   if (typeof action === "function") {
     return action(dispatchFunction);

--- a/agir/front/components/globalContext/tests/actions.test.js
+++ b/agir/front/components/globalContext/tests/actions.test.js
@@ -208,6 +208,53 @@ describe("GlobalContext/actions", function () {
       );
     });
   });
+  describe("setAnnouncementsAsRead action creator", function () {
+    afterEach(() => {
+      activityHelpers.setActivitiesAsRead.mockClear();
+    });
+    it("should call activity helper function 'setActivitiesAsRead'", function () {
+      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+      const ids = [1, 2, 3];
+      dispatch(actions.setAllActivitiesAsRead(ids));
+      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      expect(activityHelpers.setActivitiesAsRead.mock.calls[0][0]).toEqual(ids);
+    });
+    it(`should not dispatch an action of type ${ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION} if api calls rejects`, async function () {
+      activityHelpers.setActivitiesAsRead.mockResolvedValueOnce(false);
+      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+      expect(mockDispatch.mock.calls).toHaveLength(0);
+      const ids = [1, 2, 3];
+      await dispatch(actions.setAllActivitiesAsRead(ids, true));
+      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      expect(mockDispatch.mock.calls).toHaveLength(0);
+    });
+    it(`should not dispatch an action of type ${ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION} if api calls throws`, async function () {
+      jest.spyOn(console, "log").mockReturnValueOnce();
+      activityHelpers.setActivitiesAsRead.mockRejectedValueOnce(
+        new Error("Aïe!")
+      );
+      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+      expect(mockDispatch.mock.calls).toHaveLength(0);
+      const ids = [1, 2, 3];
+      await dispatch(actions.setAllActivitiesAsRead(ids, true));
+      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      expect(mockDispatch.mock.calls).toHaveLength(0);
+      console.log.mockRestore();
+    });
+    it(`should dispatch an action of type ${ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION} if api calls succeeds`, async function () {
+      activityHelpers.setActivitiesAsRead.mockResolvedValueOnce(true);
+      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+      expect(mockDispatch.mock.calls).toHaveLength(0);
+      const ids = [1, 2, 3];
+      await dispatch(actions.setAllActivitiesAsRead(ids, true));
+      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      expect(mockDispatch.mock.calls).toHaveLength(1);
+      expect(mockDispatch.mock.calls[0][0]).toHaveProperty(
+        "type",
+        ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION
+      );
+    });
+  });
   describe("createDispatch function factory", function () {
     it("should return a function", function () {
       const dispatch = createDispatch(() => {});


### PR DESCRIPTION
- Ajout d'un call API pour mettre à jour le statut des activités liées aux annonces affichées sur la page.