### PR TITLE
Group creation confirmation activity

### DIFF
--- a/agir/activity/components/common/helpers.js
+++ b/agir/activity/components/common/helpers.js
@@ -16,6 +16,7 @@ export const requiredActivityTypes = [
   "waiting-location-group",
   "group-coorganization-invite",
   "waiting-location-event",
+  "group-creation-confirmation",
 ];
 
 export const parseActivities = (data, dismissed = []) => {

--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.js
@@ -15,7 +15,15 @@ export const requiredActionTypes = [
 ];
 
 const RequiredActionCard = (props) => {
-  const { id, type, event, supportGroup, individual, onDismiss } = props;
+  const {
+    id,
+    type,
+    event,
+    supportGroup,
+    individual,
+    onDismiss,
+    routes,
+  } = props;
 
   const handleDismiss = useCallback(() => {
     onDismiss(id);
@@ -137,18 +145,17 @@ const RequiredActionCard = (props) => {
           iconName="users"
           confirmLabel="Lire l'article"
           dismissLabel="C'est fait"
-          onConfirm={supportGroup.routes && supportGroup.routes.help}
+          onConfirm={routes && routes.newGroupHelp}
           onDismiss={handleDismiss}
           text={
             <>
-              Votre groupe &laquo;&nbsp;
-              <a href={supportGroup.url}>{supportGroup.name}</a>&nbsp;&raquo;
-              est en ligne !
+              <a href={supportGroup.url}>{supportGroup.name}</a> est en ligne !
               <br />
               <br />
-              En tant qu'animateur·ice, vous pouvez gérer votre groupe à tout
-              moment depuis le bouton &laquo;&nbsp;Gestion&nbsp;&raquo; ou bien
-              en cliquant sur{" "}
+              En tant qu'animateur·ice, vous pouvez gérer{" "}
+              <a href={supportGroup.url}>{supportGroup.name}</a> à tout moment
+              depuis le bouton &laquo;&nbsp;Gestion&nbsp;&raquo; ou bien en
+              cliquant sur{" "}
               <a href={supportGroup.routes && supportGroup.routes.manage}>
                 ce lien
               </a>
@@ -156,7 +163,7 @@ const RequiredActionCard = (props) => {
               <br />
               <br />
               Nous vous conseillons de lire ces conseils à destination des
-              nouveaux animateur·ice·s de groupes.
+              nouveaux animateur·ice·s.
             </>
           }
         />
@@ -188,7 +195,6 @@ RequiredActionCard.propTypes = {
     url: PropTypes.string,
     routes: PropTypes.shape({
       manage: PropTypes.string,
-      help: PropTypes.string,
     }).isRequired,
   }),
   individual: PropTypes.shape({
@@ -196,5 +202,6 @@ RequiredActionCard.propTypes = {
     email: PropTypes.string,
   }),
   onDismiss: PropTypes.func,
+  routes: PropTypes.object,
 };
 export default RequiredActionCard;

--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.js
@@ -11,6 +11,7 @@ export const requiredActionTypes = [
   "waiting-location-group",
   "group-coorganization-invite",
   "waiting-location-event",
+  "group-creation-confirmation",
 ];
 
 const RequiredActionCard = (props) => {
@@ -20,7 +21,10 @@ const RequiredActionCard = (props) => {
     onDismiss(id);
   }, [id, onDismiss]);
 
-  const [isEmailCopied, copyEmail] = useCopyToClipboard(individual.email, 1000);
+  const [isEmailCopied, copyEmail] = useCopyToClipboard(
+    (individual && individual.email) || "",
+    1000
+  );
 
   switch (type) {
     case "waiting-payment": {
@@ -127,6 +131,37 @@ const RequiredActionCard = (props) => {
         />
       );
     }
+    case "group-creation-confirmation": {
+      return (
+        <ActionCard
+          iconName="users"
+          confirmLabel="Lire l'article"
+          dismissLabel="C'est fait"
+          onConfirm={supportGroup.routes && supportGroup.routes.help}
+          onDismiss={handleDismiss}
+          text={
+            <>
+              Votre groupe &laquo;&nbsp;
+              <a href={supportGroup.url}>{supportGroup.name}</a>&nbsp;&raquo;
+              est en ligne !
+              <br />
+              <br />
+              En tant qu'animateur·ice, vous pouvez gérer votre groupe à tout
+              moment depuis le bouton &laquo;&nbsp;Gestion&nbsp;&raquo; ou bien
+              en cliquant sur{" "}
+              <a href={supportGroup.routes && supportGroup.routes.manage}>
+                ce lien
+              </a>
+              .
+              <br />
+              <br />
+              Nous vous conseillons de lire ces conseils à destination des
+              nouveaux animateur·ice·s de groupes.
+            </>
+          }
+        />
+      );
+    }
     default:
       return null;
   }
@@ -151,6 +186,10 @@ RequiredActionCard.propTypes = {
   supportGroup: PropTypes.shape({
     name: PropTypes.string,
     url: PropTypes.string,
+    routes: PropTypes.shape({
+      manage: PropTypes.string,
+      help: PropTypes.string,
+    }).isRequired,
   }),
   individual: PropTypes.shape({
     firstName: PropTypes.string,

--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.stories.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.stories.js
@@ -38,12 +38,14 @@ WaitingPayment.args = {
     url: "/",
     routes: {
       manage: "#group__manage",
-      help: "#group__help",
     },
   },
   individual: {
     firstName: "Foo Bar",
     email: "foo@bar.com",
+  },
+  routes: {
+    newGroupHelp: "#newGroupHelp",
   },
 };
 export const GroupInvitation = Template.bind({});

--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.stories.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.stories.js
@@ -36,6 +36,10 @@ WaitingPayment.args = {
   supportGroup: {
     name: "Le Groupe",
     url: "/",
+    routes: {
+      manage: "#group__manage",
+      help: "#group__help",
+    },
   },
   individual: {
     firstName: "Foo Bar",
@@ -66,4 +70,9 @@ export const WaitingLocationEvent = Template.bind({});
 WaitingLocationEvent.args = {
   ...WaitingPayment.args,
   type: "waiting-location-event",
+};
+export const GroupCreationConfirmation = Template.bind({});
+GroupCreationConfirmation.args = {
+  ...WaitingPayment.args,
+  type: "group-creation-confirmation",
 };

--- a/agir/activity/components/page__requiredActivities/RequiredActivityList.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActivityList.js
@@ -7,7 +7,10 @@ import {
   useDispatch,
   useSelector,
 } from "@agir/front/globalContext/GlobalContext";
-import { getRequiredActionActivities } from "@agir/front/globalContext/reducers";
+import {
+  getRequiredActionActivities,
+  getRoutes,
+} from "@agir/front/globalContext/reducers";
 import { dismissRequiredActionActivity } from "@agir/front/globalContext/actions";
 
 import Activities from "@agir/activity/common/Activities";
@@ -42,6 +45,7 @@ const Counter = styled.span`
 
 const RequiredActivityList = () => {
   const activities = useSelector(getRequiredActionActivities);
+  const routes = useSelector(getRoutes);
   const dispatch = useDispatch();
 
   const handleDismiss = useCallback(
@@ -65,6 +69,7 @@ const RequiredActivityList = () => {
           CardComponent={RequiredActionCard}
           activities={activities}
           onDismiss={handleDismiss}
+          routes={routes}
         />
       </Page>
     </Layout>

--- a/agir/activity/models.py
+++ b/agir/activity/models.py
@@ -18,6 +18,7 @@ class Activity(TimeStampedModel):
     TYPE_NEW_REPORT = "new-report"
     TYPE_CANCELLED_EVENT = "cancelled-event"
     TYPE_REFERRAL = "referral-accepted"
+    TYPE_GROUP_CREATION_CONFIRMATION = "group-creation-confirmation"
     # TODO
     TYPE_GROUP_COORGANIZATION_INFO = "group-coorganization-info"
     TYPE_NEW_EVENT_AROUNDME = "new-event-aroundme"
@@ -48,6 +49,7 @@ class Activity(TimeStampedModel):
         TYPE_GROUP_COORGANIZATION_INVITE,
         TYPE_WAITING_LOCATION_GROUP,
         TYPE_WAITING_PAYMENT,
+        TYPE_GROUP_CREATION_CONFIRMATION,
     )
 
     TYPE_CHOICES = (

--- a/agir/activity/serializers.py
+++ b/agir/activity/serializers.py
@@ -30,7 +30,7 @@ class ActivitySerializer(FlexibleFieldsMixin, serializers.ModelSerializer):
         read_only=True,
     )
     supportGroup = SupportGroupSerializer(
-        source="supportgroup", fields=["name", "url"], read_only=True
+        source="supportgroup", fields=["name", "url", "routes"], read_only=True
     )
     individual = PersonSerializer(fields=["firstName", "email"], read_only=True)
 

--- a/agir/api/context_processors.py
+++ b/agir/api/context_processors.py
@@ -43,6 +43,7 @@ def basic_information(request):
         "contact": "https://infos.actionpopulaire.fr/contact/",
         "legal": "https://infos.actionpopulaire.fr/mentions-legales/",
         "nspReferral": reverse("nsp_referral"),
+        "newGroupHelp": "https://infos.actionpopulaire.fr/groupes/nouvelle-equipe/",
     }
 
     routes_2022 = {

--- a/agir/front/serializer_utils.py
+++ b/agir/front/serializer_utils.py
@@ -28,7 +28,9 @@ class RoutesField(serializers.SerializerMethodField):
     def to_representation(self, value):
         method = getattr(self.parent, self.method_name, None)
         routes = {
-            key: front_url(view_name, args=(value.pk,))
+            key: view_name
+            if view_name.startswith("http")
+            else front_url(view_name, args=(value.pk,))
             for key, view_name in self.routes.items()
         }
 

--- a/agir/groups/forms.py
+++ b/agir/groups/forms.py
@@ -14,6 +14,7 @@ from agir.groups.tasks import (
     send_support_group_creation_notification,
     send_external_join_confirmation,
     invite_to_group,
+    create_group_creation_confirmation_activity,
 )
 from agir.lib.form_components import *
 from agir.lib.form_mixins import (
@@ -154,6 +155,7 @@ class SupportGroupForm(
         if self.is_creation:
             # membership attribute created by _save_m2m
             send_support_group_creation_notification.delay(self.membership.pk)
+            create_group_creation_confirmation_activity.delay(self.membership.pk)
         else:
             # send changes notification
             if self.changed_data:

--- a/agir/groups/serializers.py
+++ b/agir/groups/serializers.py
@@ -36,6 +36,7 @@ GROUP_ROUTES = {
     "manage": "manage_group",
     "edit": "edit_group",
     "quit": "quit_group",
+    "help": "https://infos.actionpopulaire.fr/groupes/nouvelle-equipe/",
 }
 
 

--- a/agir/groups/serializers.py
+++ b/agir/groups/serializers.py
@@ -36,7 +36,6 @@ GROUP_ROUTES = {
     "manage": "manage_group",
     "edit": "edit_group",
     "quit": "quit_group",
-    "help": "https://infos.actionpopulaire.fr/groupes/nouvelle-equipe/",
 }
 
 

--- a/agir/groups/tasks.py
+++ b/agir/groups/tasks.py
@@ -80,6 +80,26 @@ def send_support_group_creation_notification(membership_pk):
     )
 
 
+@shared_task
+def create_group_creation_confirmation_activity(membership_pk):
+    try:
+        membership = Membership.objects.select_related("supportgroup", "person").get(
+            pk=membership_pk
+        )
+    except Membership.DoesNotExist:
+        return
+
+    referent = membership.person
+    group = membership.supportgroup
+
+    Activity.objects.create(
+        type=Activity.TYPE_GROUP_CREATION_CONFIRMATION,
+        recipient=referent,
+        supportgroup=group,
+        status=Activity.STATUS_UNDISPLAYED,
+    )
+
+
 @emailing_task
 def send_support_group_changed_notification(support_group_pk, changed_data):
     try:

--- a/agir/groups/tests/test_tasks.py
+++ b/agir/groups/tests/test_tasks.py
@@ -72,6 +72,23 @@ class NotificationTasksTestCase(TestCase):
                 getattr(self.group, item) in text, "{} missing in message".format(item)
             )
 
+    def test_create_group_creation_confirmation_activity(self):
+        original_target_activity_count = Activity.objects.filter(
+            type=Activity.TYPE_GROUP_CREATION_CONFIRMATION,
+            recipient=self.creator_membership.person,
+            supportgroup=self.creator_membership.supportgroup,
+        ).count()
+
+        tasks.create_group_creation_confirmation_activity(self.creator_membership.pk)
+
+        new_target_activity_count = Activity.objects.filter(
+            type=Activity.TYPE_GROUP_CREATION_CONFIRMATION,
+            recipient=self.creator_membership.person,
+            supportgroup=self.creator_membership.supportgroup,
+        ).count()
+
+        self.assertEqual(new_target_activity_count, original_target_activity_count + 1)
+
     def test_someone_joined_notification_mail(self):
         tasks.send_someone_joined_notification(self.membership1.pk)
 

--- a/agir/lib/tests/mixins.py
+++ b/agir/lib/tests/mixins.py
@@ -134,6 +134,7 @@ def create_activity(person_email):
                 Activity.TYPE_NEW_EVENT_AROUNDME,
                 Activity.TYPE_GROUP_COORGANIZATION_INFO,
                 Activity.TYPE_CANCELLED_EVENT,
+                Activity.TYPE_GROUP_CREATION_CONFIRMATION,
             ]
         ),
         "status": random.choice(


### PR DESCRIPTION
- Add "group-creation-confirmation" activity (displayed) type
- Add "group-creation-confirmation" type RequiredActionCard
- Add `create_group_creation_confirmation_activity` task
- Call `create_group_creation_confirmation_activity` task upon new supportgroup creation
- Update `RouteField` serializer to allow passing it an absolute URL as route
- Add SupportGroupSerializer `routes` field inside ActivitySerializer
