### PR TITLE
feat: abstract logging logic

### DIFF
--- a/agir/activity/components/common/helpers.js
+++ b/agir/activity/components/common/helpers.js
@@ -1,6 +1,7 @@
 import axios from "@agir/lib/utils/axios";
 
-const debug = require("debug")(`agir:${__filename}`);
+import logger from "@agir/lib/utils/log";
+const log = logger(__filename);
 
 const bulkUpdateActivityStatusEndpoint = "/api/activity/bulk/update-status/";
 const activityEndpoint = "/api/activity/:id/";
@@ -69,7 +70,7 @@ export const dismissActivity = async (
     res = await axios.put(url, data);
     result = !!res && res.status === 200;
   } catch (e) {
-    debug.extend("dismissActivity")(e);
+    log.debug(e);
     result = false;
   }
 

--- a/agir/carte/components/map/itemMap.js
+++ b/agir/carte/components/map/itemMap.js
@@ -9,7 +9,8 @@ import VectorLayer from "ol/layer/Vector";
 import { fontIsLoaded } from "./utils";
 import { makeStyle, setUpMap } from "./common";
 
-const debug = require("debug")(`agir:${__filename}`);
+import logger from "@agir/lib/utils/log";
+const log = logger(__filename);
 
 export default async function itemMap(
   htmlElementId,
@@ -28,7 +29,7 @@ export default async function itemMap(
   try {
     await fontIsLoaded("FontAwesome");
   } catch (e) {
-    debug("Error loading fonts."); // eslint-disable-line no-console
+    log.debug("Error loading fonts."); // eslint-disable-line no-console
   }
 
   const map = setUpMap(htmlElementId, [layer]);

--- a/agir/carte/components/map/listMap.js
+++ b/agir/carte/components/map/listMap.js
@@ -13,7 +13,8 @@ import makeLayerControl from "./layerControl";
 import makeSearchControl from "./searchControl";
 import getFormatPopups from "./itemPopups";
 
-const debug = require("debug")(`agir:${__filename}`);
+import logger from "@agir/lib/utils/log";
+const log = logger(__filename);
 
 const OFFSET = 0.00005;
 
@@ -193,7 +194,7 @@ export default async function listMap(
   try {
     await fontIsLoaded("FontAwesome");
   } catch (e) {
-    debug("Error loading fonts."); // eslint-disable-line no-console
+    log.debug("Error loading fonts."); // eslint-disable-line no-console
   }
 
   disambiguate(res.data);

--- a/agir/carte/components/page__eventMap/index.js
+++ b/agir/carte/components/page__eventMap/index.js
@@ -1,6 +1,7 @@
 import onDOMReady from "@agir/lib/utils/onDOMReady";
 
-const debug = require("debug")(`agir:${__filename}`);
+import logger from "@agir/lib/utils/log";
+const log = logger(__filename);
 
 (async function () {
   const [
@@ -22,7 +23,7 @@ const debug = require("debug")(`agir:${__filename}`);
       return;
     }
     const payload = JSON.parse(dataElement.textContent);
-    debug(payload);
+    log.debug(payload);
     renderReactComponent(
       <GlobalContextProvider>
         <EventMap {...payload} />

--- a/agir/carte/components/page__groupMap/index.js
+++ b/agir/carte/components/page__groupMap/index.js
@@ -1,6 +1,6 @@
 import onDOMReady from "@agir/lib/utils/onDOMReady";
 
-const debug = require("debug")(`agir:${__filename}`);
+import logger from "@agir/lib/utils/log";
 
 (async function () {
   const [
@@ -22,7 +22,7 @@ const debug = require("debug")(`agir:${__filename}`);
       return;
     }
     const payload = JSON.parse(dataElement.textContent);
-    debug(payload);
+    log.debug(payload);
     renderReactComponent(
       <GlobalContextProvider>
         <GroupMap {...payload} />

--- a/agir/lib/components/utils/log.js
+++ b/agir/lib/components/utils/log.js
@@ -1,0 +1,10 @@
+import debug from "debug";
+
+const generateLogger = (filename) => ({
+  debug: debug(`agir:${filename.replace("/", ":").replace(".js", "")}`),
+  warn: console.warn,
+  info: console.info,
+  error: console.error,
+});
+
+export default generateLogger;


### PR DESCRIPTION
Autre proposition suite à discution avec @giuseppedeponte.

L'idée est d'abstraire la destination des logs de l'outil de log lui-même, un peu comme en python.

log.debug utilise donc debug, qui permet de logger dans la console uniquement quand env DEBUG contient quelque chose, avec un timer de millisecondes, les autres utilisent console.log, mais on peut imaginer qu'ils aient un backend différent à terme

