### PR TITLE
Titre OpenGraph pour les groupes et événements

### DIFF
--- a/agir/events/views/event_views.py
+++ b/agir/events/views/event_views.py
@@ -113,8 +113,6 @@ class EventDetailMixin(GlobalOrObjectPermissionRequiredMixin):
         Event.objects.all()
     )  # y compris les événements cachés, pour pouvoir montrer des pages GONE
 
-    title_prefix = _("Evénement local")
-
     def handle_no_permission(self):
         if self.get_object().visibility == Event.VISIBILITY_ADMIN:
             return HttpResponseGone()

--- a/agir/front/view_mixins.py
+++ b/agir/front/view_mixins.py
@@ -46,14 +46,14 @@ class SimpleOpengraphMixin(ContextMixin):
 
 
 class ObjectOpengraphMixin(SimpleOpengraphMixin):
-    title_prefix = "Action Populaire"
+    title_suffix = "Action Populaire"
 
     image_lfi = static("front/assets/og_image_LFI.jpg")
     image_nsp = static("front/assets/og_image_NSP.jpg")
 
     # noinspection PyUnresolvedReferences
     def get_meta_title(self):
-        return "{} - {}".format(self.title_prefix, self.object.name)
+        return "{} — {}".format(self.object.name, self.title_suffix)
 
     def is_2022_object(self):
         return hasattr(self.object, "is_2022") and self.object.is_2022 == True

--- a/agir/groups/views/public_views.py
+++ b/agir/groups/views/public_views.py
@@ -69,9 +69,8 @@ class SupportGroupDetailView(
     template_name = "groups/detail.html"
     model = SupportGroup
 
-    title_prefix = "Groupe"
     meta_description = "Rejoignez les groupes d'action de la France insoumise."
-    meta_description_2022 = "Rejoignez les groupes de soutien de votre quartier pour la candidature de Jean-Luc Mélenchon pour 2022"
+    meta_description_2022 = "Rejoignez les équipes de soutien de votre quartier pour la candidature de Jean-Luc Mélenchon pour 2022"
 
     def handle_no_permission(self):
         return HttpResponseGone()


### PR DESCRIPTION
Je propose de modifier ce qui existe actuellement pour ne plus afficher le type
d'objet (groupe ou événement) parce que cela peut généralement être déduit du
nom de l'objet, et d'afficher « Action Populaire » en suffixe plutôt qu'en
préfixe.
