### PR TITLE
Waiting location activities

### DIFF
--- a/agir/activity/components/page__activities/ActivityCard.js
+++ b/agir/activity/components/page__activities/ActivityCard.js
@@ -1,5 +1,5 @@
 import Card from "@agir/front/genericComponents/Card";
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { Interval } from "luxon";
@@ -11,257 +11,11 @@ import FeatherIcon from "@agir/front/genericComponents/FeatherIcon";
 import { dateFromISOString, displayHumanDate } from "@agir/lib/utils/time";
 import { activityStatus } from "@agir/activity/common/helpers";
 
-const eventCardTypes = [
-  "group-coorganization-accepted",
-  "event-update",
-  "new-event-mygroups",
-  "new-report",
-  "new-event-aroundme",
-  "group-coorganization-info",
-];
-
-export const activityCardIcons = {
-  "waiting-payment": "alert-circle",
-  "group-invitation": "mail",
-  "new-member": "user-plus",
-  "waiting-location-group": "alert-circle",
-  "group-coorganization-invite": "mail",
-  "waiting-location-event": "alert-circle",
-  "group-coorganization-accepted": "calendar",
-  "group-info-update": "info",
-  "accepted-invitation-member": "user-plus",
-  "new-attendee": "user-plus",
-  "event-update": "info",
-  "new-event-mygroups": "calendar",
-  "new-report": "file-text",
-  "new-event-aroundme": "calendar",
-  "group-coorganization-info": "calendar",
-  "cancelled-event": "x-circle",
-  "referral-accepted": "share-2",
-  "transferred-group-member": "info",
-  "new-members-through-transfer": "user-plus",
-};
+import CONFIG from "./activity.config.json";
 
 const StyledParagraph = styled.p`
   margin-bottom: 0;
 `;
-
-const ReferralUpdateActivityText = React.memo(
-  ({ individual, meta: { totalReferrals }, routes }) => {
-    if (totalReferrals < 5) {
-      return (
-        <StyledParagraph>
-          Grâce à vous, {individual || "quelqu'un"} a parrainé la candidature de
-          Jean-Luc Mélenchon.
-          <br />
-          Merci beaucoup, continuez à partager ! 👍
-        </StyledParagraph>
-      );
-    }
-    if (totalReferrals === 5) {
-      return (
-        <StyledParagraph>
-          5 personnes ont parrainé la candidature de Jean-Luc Mélenchon grâce à
-          vous ! La campagne de signature continue, invitez vos amis à partager
-          leur lien personnalisé à leur tour !
-        </StyledParagraph>
-      );
-    }
-    if (totalReferrals < 10) {
-      return (
-        <StyledParagraph>
-          Encore un ! {individual} a parrainé la candidature de Jean-Luc
-          Mélenchon.
-          <br />
-          C'est super, vous avez fait signer {totalReferrals} personnes !
-          Continuez comme ça ! 😀
-        </StyledParagraph>
-      );
-    }
-    if (totalReferrals === 10) {
-      return (
-        <StyledParagraph>
-          Vous avez permis la signature de 10 personnes ! Quel est votre secret
-          ?!
-          <br />
-          Si vous n'y aviez pas encore songé, il est peut-être temps de{" "}
-          <a href={routes.createGroup}>
-            créer une équipe de soutien dans votre ville
-          </a>{" "}
-          ;)
-        </StyledParagraph>
-      );
-    }
-    if (totalReferrals === 20) {
-      return (
-        <StyledParagraph>
-          Grâce à vous, 20 personnes ont parrainé la candidature de Jean-Luc
-          Mélenchon !<br />
-          Beau travail ! Prochaine étape :{" "}
-          <a href={routes.createEvent}>organiser un événement en ligne</a> pour
-          récolter encore plus de signatures !
-        </StyledParagraph>
-      );
-    }
-    return (
-      <StyledParagraph>
-        Et de {totalReferrals} ! {individual} a parrainé la candidature de
-        Jean-Luc Mélenchon. Génial ! 😍
-      </StyledParagraph>
-    );
-  }
-);
-ReferralUpdateActivityText.displayName = "ReferralUpdateActivityText";
-ReferralUpdateActivityText.propTypes = {
-  individual: PropTypes.node,
-  meta: PropTypes.shape({
-    totalReferrals: PropTypes.number.isRequired,
-  }).isRequired,
-  routes: PropTypes.shape({
-    createEvent: PropTypes.string,
-    createGroup: PropTypes.string,
-  }),
-};
-const ActivityText = React.memo((props) => {
-  const {
-    type,
-    event,
-    supportGroup,
-    supportGroupManage,
-    individual,
-    meta,
-  } = props;
-  switch (type) {
-    case "waiting-payment":
-      return (
-        <StyledParagraph>
-          Vous n'avez pas encore réglé votre place pour l'événément {event}
-        </StyledParagraph>
-      );
-    case "group-invitation":
-      return (
-        <StyledParagraph>
-          Vous avez été invité⋅e à rejoindre {supportGroup}
-        </StyledParagraph>
-      );
-    case "new-member":
-      return (
-        <StyledParagraph>
-          {individual || "Quelqu'un"} a rejoint {supportGroup}. Prenez le temps
-          de l’accueillir&nbsp;!
-        </StyledParagraph>
-      );
-    case "waiting-location-group":
-      return (
-        <StyledParagraph>
-          Précisez la localisation de {supportGroup}
-        </StyledParagraph>
-      );
-    case "group-coorganization-invite":
-      return (
-        <StyledParagraph>
-          {individual || "Quelqu'un"} a proposé à {supportGroup} de co-organiser{" "}
-          {event}
-        </StyledParagraph>
-      );
-    case "waiting-location-event":
-      return (
-        <StyledParagraph>
-          Précisez la localisation de votre événement&nbsp;: {event}
-        </StyledParagraph>
-      );
-    case "group-coorganization-accepted":
-      return (
-        <StyledParagraph>
-          {supportGroup} a accepté de co-organiser votre événement {event}
-        </StyledParagraph>
-      );
-    case "group-info-update":
-      return <StyledParagraph>{supportGroup} a été mis à jour</StyledParagraph>;
-    case "accepted-invitation-member":
-      return (
-        <StyledParagraph>
-          {individual || "Quelqu'un"} a rejoint {supportGroup} en acceptant une
-          invitation.
-        </StyledParagraph>
-      );
-    case "new-attendee":
-      return (
-        <StyledParagraph>
-          {individual || "Quelqu'un"} s'est inscrit à votre événement {event}
-        </StyledParagraph>
-      );
-    case "event-update":
-      return (
-        <StyledParagraph>
-          Mise à jour : l'événement {event} auquel vous participez a changé de
-          date.
-        </StyledParagraph>
-      );
-    case "new-event-mygroups":
-      return (
-        <StyledParagraph>
-          {supportGroup || individual || "Quelqu'un"} a publié un nouvel
-          événement
-        </StyledParagraph>
-      );
-    case "new-report":
-      return (
-        <StyledParagraph>
-          Le compte-rendu de l'événement {event} a été ajouté par les
-          organisateurs
-        </StyledParagraph>
-      );
-    case "new-event-aroundme":
-      return (
-        <StyledParagraph>
-          Un nouvel événement a été publié près de chez vous par{" "}
-          {supportGroup || individual || "quelqu'un"}
-        </StyledParagraph>
-      );
-    case "group-coorganization-info":
-      return (
-        <StyledParagraph>
-          {supportGroup} a rejoint l'organisation de l'événement {event}
-        </StyledParagraph>
-      );
-    case "cancelled-event":
-      return (
-        <StyledParagraph>L'événement {event} a été annulé.</StyledParagraph>
-      );
-    case "referral-accepted":
-      return <ReferralUpdateActivityText {...props} />;
-    case "transferred-group-member":
-      return (
-        <StyledParagraph>
-          Vous avez été transféré·e de &laquo;&nbsp;{meta && meta.oldGroup}
-          &nbsp;&raquo; et avez rejoint {supportGroup}.<br />
-          Votre nouvelle équipe vous attend !
-        </StyledParagraph>
-      );
-    case "new-members-through-transfer":
-      return (
-        <StyledParagraph>
-          {meta && meta.transferredMemberships} membre
-          {meta && meta.transferredMemberships > 0 ? "s" : ""} ont rejoint{" "}
-          {supportGroupManage} suite à un transfert depuis &laquo;&nbsp;
-          {meta && meta.oldGroup}&nbsp;&raquo;.
-        </StyledParagraph>
-      );
-    default:
-      return null;
-  }
-});
-ActivityText.displayName = "ActivityText";
-ActivityText.propTypes = {
-  type: PropTypes.string,
-  event: PropTypes.node,
-  supportGroup: PropTypes.node,
-  supportGroupManage: PropTypes.node,
-  individual: PropTypes.node,
-  routes: PropTypes.object,
-  meta: PropTypes.object,
-};
 
 const LowMarginCard = styled(Card)`
   @media only screen and (min-width: ${style.collapse}px) {
@@ -291,30 +45,26 @@ const EventCardContainer = styled.div`
   }
 `;
 
-const ActivityCard = (props) => {
-  const { routes, supportGroup, type, individual, status, meta } = props;
-  let { timestamp, event } = props;
+const ActivityCardContainer = React.memo((props) => {
+  const { status, type, timestamp, event, children } = props;
 
-  timestamp = dateFromISOString(timestamp);
+  const date = useMemo(
+    () =>
+      displayHumanDate(dateFromISOString(timestamp))
+        .split("")
+        .map((ch, i) => (i ? ch : ch.toUpperCase()))
+        .join(""),
+    [timestamp]
+  );
 
-  let textProps = {
-    type: type,
-    event: event && <a href={event.routes.details}>{event.name}</a>,
-    supportGroup: supportGroup && (
-      <a href={supportGroup.url}>{supportGroup.name}</a>
-    ),
-    supportGroupManage: supportGroup && supportGroup.routes && (
-      <a href={supportGroup.routes.manage}>{supportGroup.name}</a>
-    ),
-    individual: individual && <strong>{individual.firstName}</strong>,
-  };
+  const iconName = useMemo(() => CONFIG[type].icon || "info", [type]);
 
-  event = event && {
-    ...event,
-    schedule: Interval.fromISO(`${event.startTime}/${event.endTime}`),
-  };
+  const eventSchedule = useMemo(
+    () => event && Interval.fromISO(`${event.startTime}/${event.endTime}`),
+    [event]
+  );
 
-  if (!activityCardIcons[props.type]) {
+  if (!CONFIG[type]) {
     return null;
   }
 
@@ -322,10 +72,10 @@ const ActivityCard = (props) => {
     <LowMarginCard isUnread={status === activityStatus.STATUS_UNDISPLAYED}>
       <Row gutter="8" align="flex-start">
         <Column width="1rem" collapse={0} style={{ paddingTop: "2px" }}>
-          <FeatherIcon name={activityCardIcons[type]} color={style.black500} />
+          <FeatherIcon name={iconName} color={style.black500} />
         </Column>
         <Column collapse={0} grow style={{ fontSize: "15px" }}>
-          <ActivityText {...textProps} routes={routes} meta={meta} />
+          <StyledParagraph>{children}</StyledParagraph>
           <p
             style={{
               margin: "0.125rem 0 0",
@@ -334,40 +84,258 @@ const ActivityCard = (props) => {
               fontWeight: 400,
             }}
           >
-            {displayHumanDate(timestamp)
-              .split("")
-              .map((ch, i) => (i ? ch : ch.toUpperCase()))
-              .join("")}
+            {date}
           </p>
         </Column>
       </Row>
-      {eventCardTypes.includes(type) && (
+      {CONFIG[type].hasEvent && (
         <EventCardContainer>
-          <EventCard {...event} />
+          <EventCard {...event} schedule={eventSchedule} />
         </EventCardContainer>
       )}
     </LowMarginCard>
   );
+});
+ActivityCardContainer.displayName = "ActivityCardContainer";
+ActivityCardContainer.propTypes = {
+  status: PropTypes.oneOf(Object.values(activityStatus)),
+  type: PropTypes.string.isRequired,
+  event: PropTypes.object, // see event card PropTypes
+  timestamp: PropTypes.string.isRequired,
+  children: PropTypes.node,
 };
 
-ActivityCard.propTypes = {
-  id: PropTypes.number.isRequired,
-  type: PropTypes.string.isRequired,
-  status: PropTypes.oneOf(Object.values(activityStatus)),
-  event: PropTypes.object, // see event card PropTypes
-  supportGroup: PropTypes.shape({
-    name: PropTypes.string,
-    url: PropTypes.string,
-    routes: PropTypes.object,
-  }),
-  individual: PropTypes.shape({ firstName: PropTypes.string }),
+const ReferralUpdateActivityText = (props) => {
+  const {
+    individual,
+    meta: { totalReferrals },
+    routes,
+  } = props;
+  if (totalReferrals < 5) {
+    return (
+      <ActivityCardContainer {...props}>
+        Grâce à vous, {individual || "quelqu'un"} a parrainé la candidature de
+        Jean-Luc Mélenchon.
+        <br />
+        Merci beaucoup, continuez à partager ! 👍
+      </ActivityCardContainer>
+    );
+  }
+  if (totalReferrals === 5) {
+    return (
+      <ActivityCardContainer {...props}>
+        5 personnes ont parrainé la candidature de Jean-Luc Mélenchon grâce à
+        vous ! La campagne de signature continue, invitez vos amis à partager
+        leur lien personnalisé à leur tour !
+      </ActivityCardContainer>
+    );
+  }
+  if (totalReferrals < 10) {
+    return (
+      <ActivityCardContainer {...props}>
+        Encore un ! {individual} a parrainé la candidature de Jean-Luc
+        Mélenchon.
+        <br />
+        C'est super, vous avez fait signer {totalReferrals} personnes !
+        Continuez comme ça ! 😀
+      </ActivityCardContainer>
+    );
+  }
+  if (totalReferrals === 10) {
+    return (
+      <ActivityCardContainer {...props}>
+        Vous avez permis la signature de 10 personnes ! Quel est votre secret ?!
+        <br />
+        Si vous n'y aviez pas encore songé, il est peut-être temps de{" "}
+        <a href={routes.createGroup}>
+          créer une équipe de soutien dans votre ville
+        </a>{" "}
+        ;)
+      </ActivityCardContainer>
+    );
+  }
+  if (totalReferrals === 20) {
+    return (
+      <ActivityCardContainer {...props}>
+        Grâce à vous, 20 personnes ont parrainé la candidature de Jean-Luc
+        Mélenchon !<br />
+        Beau travail ! Prochaine étape :{" "}
+        <a href={routes.createEvent}>organiser un événement en ligne</a> pour
+        récolter encore plus de signatures !
+      </ActivityCardContainer>
+    );
+  }
+  return (
+    <ActivityCardContainer {...props}>
+      Et de {totalReferrals} ! {individual} a parrainé la candidature de
+      Jean-Luc Mélenchon. Génial ! 😍
+    </ActivityCardContainer>
+  );
+};
+ReferralUpdateActivityText.propTypes = {
+  individual: PropTypes.node,
   meta: PropTypes.shape({
-    totalReferrals: PropTypes.number,
-    oldGroup: PropTypes.string,
-    transferredMemberships: PropTypes.number,
+    totalReferrals: PropTypes.number.isRequired,
+  }).isRequired,
+  routes: PropTypes.shape({
+    createEvent: PropTypes.string,
+    createGroup: PropTypes.string,
   }),
-  timestamp: PropTypes.string.isRequired,
+};
+
+const ActivityCard = (props) => {
+  const { type, meta, event, supportGroup, individual } = props;
+
+  const { Event, SupportGroup, Individual } = useMemo(
+    () => ({
+      Event: event && <a href={event.routes.details}>{event.name}</a>,
+      SupportGroup: supportGroup && (
+        <a href={supportGroup.url}>{supportGroup.name}</a>
+      ),
+      Individual: individual && <strong>{individual.firstName}</strong>,
+    }),
+    [event, supportGroup, individual]
+  );
+
+  if (!CONFIG[type]) {
+    return null;
+  }
+
+  switch (type) {
+    case "waiting-payment":
+      return (
+        <ActivityCardContainer {...props}>
+          Vous n'avez pas encore réglé votre place pour l'événément {Event}
+        </ActivityCardContainer>
+      );
+    case "group-invitation":
+      return (
+        <ActivityCardContainer {...props}>
+          Vous avez été invité⋅e à rejoindre {SupportGroup}
+        </ActivityCardContainer>
+      );
+    case "new-member":
+      return (
+        <ActivityCardContainer {...props}>
+          {Individual || "Quelqu'un"} a rejoint {SupportGroup}. Prenez le temps
+          de l’accueillir&nbsp;!
+        </ActivityCardContainer>
+      );
+    case "waiting-location-group":
+      return (
+        <ActivityCardContainer {...props}>
+          Précisez la localisation de {SupportGroup}
+        </ActivityCardContainer>
+      );
+    case "group-coorganization-invite":
+      return (
+        <ActivityCardContainer {...props}>
+          {Individual || "Quelqu'un"} a proposé à {SupportGroup} de co-organiser{" "}
+          {Event}
+        </ActivityCardContainer>
+      );
+    case "waiting-location-event":
+      return (
+        <ActivityCardContainer {...props}>
+          Précisez la localisation de votre événement&nbsp;: {Event}
+        </ActivityCardContainer>
+      );
+    case "group-coorganization-accepted":
+      return (
+        <ActivityCardContainer {...props}>
+          {SupportGroup} a accepté de co-organiser votre événement {Event}
+        </ActivityCardContainer>
+      );
+    case "group-info-update":
+      return (
+        <ActivityCardContainer {...props}>
+          {SupportGroup} a été mis à jour
+        </ActivityCardContainer>
+      );
+    case "accepted-invitation-member":
+      return (
+        <ActivityCardContainer {...props}>
+          {Individual || "Quelqu'un"} a rejoint {SupportGroup} en acceptant une
+          invitation.
+        </ActivityCardContainer>
+      );
+    case "new-attendee":
+      return (
+        <ActivityCardContainer {...props}>
+          {Individual || "Quelqu'un"} s'est inscrit à votre événement {Event}
+        </ActivityCardContainer>
+      );
+    case "event-update":
+      return (
+        <ActivityCardContainer {...props}>
+          Mise à jour : l'événement {Event} auquel vous participez a changé de
+          date.
+        </ActivityCardContainer>
+      );
+    case "new-event-mygroups":
+      return (
+        <ActivityCardContainer {...props}>
+          {SupportGroup || Individual || "Quelqu'un"} a publié un nouvel
+          événement
+        </ActivityCardContainer>
+      );
+    case "new-report":
+      return (
+        <ActivityCardContainer {...props}>
+          Le compte-rendu de l'événement {Event} a été ajouté par les
+          organisateurs
+        </ActivityCardContainer>
+      );
+    case "new-event-aroundme":
+      return (
+        <ActivityCardContainer {...props}>
+          Un nouvel événement a été publié près de chez vous par{" "}
+          {SupportGroup || Individual || "quelqu'un"}
+        </ActivityCardContainer>
+      );
+    case "group-coorganization-info":
+      return (
+        <ActivityCardContainer {...props}>
+          {SupportGroup} a rejoint l'organisation de l'événement {Event}
+        </ActivityCardContainer>
+      );
+    case "cancelled-event":
+      return (
+        <ActivityCardContainer {...props}>
+          L'événement {Event} a été annulé.
+        </ActivityCardContainer>
+      );
+    case "referral-accepted":
+      return <ReferralUpdateActivityText {...props} individual={Individual} />;
+    case "transferred-group-member":
+      return (
+        <ActivityCardContainer {...props}>
+          Vous avez été transféré·e de &laquo;&nbsp;{meta && meta.oldGroup}
+          &nbsp;&raquo; et avez rejoint {SupportGroup}.<br />
+          Votre nouvelle équipe vous attend !
+        </ActivityCardContainer>
+      );
+    case "new-members-through-transfer":
+      return (
+        <ActivityCardContainer {...props}>
+          {meta && meta.transferredMemberships} membre
+          {meta && meta.transferredMemberships > 0 ? "s" : ""} ont rejoint{" "}
+          <a href={supportGroup.routes.manage}>{supportGroup.name}</a> suite à
+          un transfert depuis &laquo;&nbsp;
+          {meta && meta.oldGroup}&nbsp;&raquo;.
+        </ActivityCardContainer>
+      );
+    default:
+      return null;
+  }
+};
+ActivityCard.propTypes = {
+  type: PropTypes.string,
+  event: PropTypes.object,
+  supportGroup: PropTypes.object,
+  individual: PropTypes.object,
   routes: PropTypes.object,
+  meta: PropTypes.object,
 };
 
 export default ActivityCard;

--- a/agir/activity/components/page__activities/ActivityCard.stories.js
+++ b/agir/activity/components/page__activities/ActivityCard.stories.js
@@ -1,7 +1,7 @@
 import { Default as EventCardStory } from "@agir/front/genericComponents/EventCard.stories";
 
 import ActivityCard from "./ActivityCard";
-import { activityCardIcons } from "./ActivityCard";
+import CONFIG from "./activity.config.json";
 import { DateTime } from "luxon";
 import { decorateArgs, reorganize } from "@agir/lib/utils/storyUtils";
 
@@ -13,7 +13,7 @@ export default {
       name: "Type de carte",
       control: {
         type: "select",
-        options: Object.keys(activityCardIcons),
+        options: Object.keys(CONFIG),
       },
     },
     event: {

--- a/agir/activity/components/page__activities/activity.config.json
+++ b/agir/activity/components/page__activities/activity.config.json
@@ -1,0 +1,65 @@
+{
+  "waiting-payment": {
+    "icon": "alert-circle"
+  },
+  "group-invitation": {
+    "icon": "mail"
+  },
+  "new-member": {
+    "icon": "user-plus"
+  },
+  "waiting-location-group": {
+    "icon": "alert-circle"
+  },
+  "group-coorganization-invite": {
+    "icon": "mail"
+  },
+  "waiting-location-event": {
+    "icon": "alert-circle"
+  },
+  "group-coorganization-accepted": {
+    "icon": "calendar",
+    "hasEvent": true
+  },
+  "group-info-update": {
+    "icon": "info"
+  },
+  "accepted-invitation-member": {
+    "icon": "user-plus"
+  },
+  "new-attendee": {
+    "icon": "user-plus"
+  },
+  "event-update": {
+    "icon": "info",
+    "hasEvent": true
+  },
+  "new-event-mygroups": {
+    "icon": "calendar",
+    "hasEvent": true
+  },
+  "new-report": {
+    "icon": "file-text",
+    "hasEvent": true
+  },
+  "new-event-aroundme": {
+    "icon": "calendar",
+    "hasEvent": true
+  },
+  "group-coorganization-info": {
+    "icon": "calendar",
+    "hasEvent": true
+  },
+  "cancelled-event": {
+    "icon": "x-circle"
+  },
+  "referral-accepted": {
+    "icon": "share-2"
+  },
+  "transferred-group-member": {
+    "icon": "info"
+  },
+  "new-members-through-transfer": {
+    "icon": "user-plus"
+  }
+}

--- a/agir/activity/models.py
+++ b/agir/activity/models.py
@@ -22,14 +22,14 @@ class Activity(TimeStampedModel):
     TYPE_GROUP_CREATION_CONFIRMATION = "group-creation-confirmation"
     TYPE_TRANSFERRED_GROUP_MEMBER = "transferred-group-member"
     TYPE_NEW_MEMBERS_THROUGH_TRANSFER = "new-members-through-transfer"
+    TYPE_WAITING_LOCATION_EVENT = "waiting-location-event"
+    TYPE_WAITING_LOCATION_GROUP = "waiting-location-group"
     # TODO
     TYPE_GROUP_COORGANIZATION_INFO = "group-coorganization-info"
     TYPE_NEW_EVENT_AROUNDME = "new-event-aroundme"
     TYPE_ACCEPTED_INVITATION_MEMBER = "accepted-invitation-member"
     TYPE_GROUP_COORGANIZATION_ACCEPTED = "group-coorganization-accepted"
-    TYPE_WAITING_LOCATION_EVENT = "waiting-location-event"
     TYPE_GROUP_COORGANIZATION_INVITE = "group-coorganization-invite"
-    TYPE_WAITING_LOCATION_GROUP = "waiting-location-group"
     TYPE_WAITING_PAYMENT = "waiting-payment"
     # Sans affichage d'une notification
     TYPE_ANNOUNCEMENT = "announcement"

--- a/agir/events/forms.py
+++ b/agir/events/forms.py
@@ -33,9 +33,9 @@ from .tasks import (
     send_external_rsvp_confirmation,
     send_secretariat_notification,
     notify_on_event_report,
+    geocode_event,
 )
 from ..lib.form_fields import AcceptCreativeCommonsLicenceField
-from ..lib.tasks import geocode_event
 from ..people.models import Person, PersonFormSubmission
 
 __all__ = [

--- a/agir/events/tasks.py
+++ b/agir/events/tasks.py
@@ -498,3 +498,14 @@ def geocode_event(event_pk):
 
     geocode_element(event)
     event.save()
+
+    if (
+        event.coordinates_type is not None
+        and event.coordinates_type >= Event.COORDINATES_NO_POSITION
+    ):
+        Activity.objects.bulk_create(
+            Activity(
+                type=Activity.TYPE_WAITING_LOCATION_EVENT, recipient=r, event=event
+            )
+            for r in event.organizers.all()
+        )

--- a/agir/events/tasks.py
+++ b/agir/events/tasks.py
@@ -15,6 +15,7 @@ from agir.authentication.tokens import subscription_confirmation_token_generator
 from agir.lib.celery import emailing_task, http_task
 from agir.lib.display import str_summary
 from agir.lib.html import sanitize_html
+from agir.lib.geo import geocode_element
 from agir.lib.mailing import send_mosaico_email
 from agir.lib.utils import front_url
 from agir.people.models import Person
@@ -486,3 +487,14 @@ def notify_on_event_report(event_pk):
         Activity(type=Activity.TYPE_NEW_REPORT, recipient=r, event=event)
         for r in event.attendees.all()
     )
+
+
+@http_task
+def geocode_event(event_pk):
+    try:
+        event = Event.objects.get(pk=event_pk)
+    except Event.DoesNotExist:
+        return
+
+    geocode_element(event)
+    event.save()

--- a/agir/groups/forms.py
+++ b/agir/groups/forms.py
@@ -22,6 +22,7 @@ from agir.groups.tasks import (
     send_external_join_confirmation,
     invite_to_group,
     create_group_creation_confirmation_activity,
+    geocode_support_group,
 )
 from agir.groups.actions.transfer import (
     send_membership_transfer_email_notifications,
@@ -36,7 +37,6 @@ from agir.lib.form_mixins import (
     SearchByZipCodeFormBase,
     ImageFormMixin,
 )
-from agir.lib.tasks import geocode_support_group
 from agir.people.models import Person
 
 __all__ = [

--- a/agir/groups/tasks.py
+++ b/agir/groups/tasks.py
@@ -9,7 +9,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from agir.authentication.tokens import subscription_confirmation_token_generator
 from agir.events.models import Event, OrganizerConfig
-from agir.lib.celery import emailing_task
+from agir.lib.celery import emailing_task, http_task
+from agir.lib.geo import geocode_element
 from agir.lib.mailing import send_mosaico_email
 from agir.lib.utils import front_url
 from agir.people.actions.subscription import make_subscription_token
@@ -388,3 +389,14 @@ def send_membership_transfer_alert(bindings, recipient_pk):
         recipients=[recipient],
         bindings=bindings,
     )
+
+
+@http_task
+def geocode_support_group(support_group_pk):
+    try:
+        support_group = SupportGroup.objects.get(pk=support_group_pk)
+    except SupportGroup.DoesNotExist:
+        return
+
+    geocode_element(support_group)
+    support_group.save()

--- a/agir/groups/tests/test_tasks.py
+++ b/agir/groups/tests/test_tasks.py
@@ -1,11 +1,13 @@
 from faker import Faker
 from unittest.mock import patch
 
+from django.db.models import Q
 from django.core import mail
 from django.shortcuts import reverse as dj_reverse
 from django.test import TestCase
 from django.utils import timezone
 
+from agir.lib.tests.mixins import create_group, create_location
 from agir.people.models import Person
 from .. import tasks
 from ..actions.notifications import someone_joined_notification
@@ -15,6 +17,17 @@ from ..tasks import send_joined_notification_email
 from ...activity.models import Activity
 
 fake = Faker("fr_FR")
+
+
+def mock_geocode_element_no_position(supportgroup):
+    supportgroup.coordinates = None
+    supportgroup.coordinates_type = SupportGroup.COORDINATES_NO_POSITION
+
+
+def mock_geocode_element_with_position(event):
+    location = create_location()
+    event.coordinates = location["coordinates"]
+    event.coordinates_type = location["coordinates_type"]
 
 
 class NotificationTasksTestCase(TestCase):
@@ -334,3 +347,75 @@ class NotificationTasksTestCase(TestCase):
         geocode_element.assert_not_called()
         tasks.geocode_support_group(fake.uuid4())
         geocode_element.assert_not_called()
+
+    @patch(
+        "agir.groups.tasks.geocode_element",
+        side_effect=mock_geocode_element_no_position,
+    )
+    def test_geocode_support_group_creates_activity_if_no_geolocation_is_found(
+        self, geocode_element
+    ):
+        supportgroup = self.group
+        managers_filter = (
+            Q(membership_type__gte=Membership.MEMBERSHIP_TYPE_MANAGER)
+        ) & Q(notifications_enabled=True)
+        managing_membership = supportgroup.memberships.filter(managers_filter)
+        managing_membership_recipients = [
+            membership.person for membership in managing_membership
+        ]
+        old_activity_count = Activity.objects.filter(
+            type=Activity.TYPE_WAITING_LOCATION_GROUP,
+            recipient__in=managing_membership_recipients,
+            supportgroup=supportgroup,
+        ).count()
+        tasks.geocode_support_group(supportgroup.pk)
+        geocode_element.assert_called_once_with(supportgroup)
+        supportgroup.refresh_from_db()
+        self.assertEqual(
+            supportgroup.coordinates_type, SupportGroup.COORDINATES_NO_POSITION
+        )
+
+        new_activity_count = Activity.objects.filter(
+            type=Activity.TYPE_WAITING_LOCATION_GROUP,
+            recipient__in=managing_membership_recipients,
+            supportgroup=supportgroup,
+        ).count()
+
+        self.assertEqual(
+            new_activity_count, old_activity_count + managing_membership.count()
+        )
+
+    @patch(
+        "agir.groups.tasks.geocode_element",
+        side_effect=mock_geocode_element_with_position,
+    )
+    def test_geocode_support_group_does_not_create_activity_if_geolocation_is_found(
+        self, geocode_element
+    ):
+        supportgroup = self.group
+        managers_filter = (
+            Q(membership_type__gte=Membership.MEMBERSHIP_TYPE_MANAGER)
+        ) & Q(notifications_enabled=True)
+        managing_membership = supportgroup.memberships.filter(managers_filter)
+        managing_membership_recipients = [
+            membership.person for membership in managing_membership
+        ]
+        old_activity_count = Activity.objects.filter(
+            type=Activity.TYPE_WAITING_LOCATION_GROUP,
+            recipient__in=managing_membership_recipients,
+            supportgroup=supportgroup,
+        ).count()
+        tasks.geocode_support_group(supportgroup.pk)
+        geocode_element.assert_called_once_with(supportgroup)
+        supportgroup.refresh_from_db()
+        self.assertLess(
+            supportgroup.coordinates_type, SupportGroup.COORDINATES_NO_POSITION
+        )
+
+        new_activity_count = Activity.objects.filter(
+            type=Activity.TYPE_WAITING_LOCATION_GROUP,
+            recipient__in=managing_membership_recipients,
+            supportgroup=supportgroup,
+        ).count()
+
+        self.assertEqual(new_activity_count, old_activity_count)

--- a/agir/lib/tasks.py
+++ b/agir/lib/tasks.py
@@ -22,6 +22,4 @@ def create_geocoder(model):
     return http_task(geocode_model)
 
 
-geocode_event = create_geocoder(Event)
-geocode_support_group = create_geocoder(SupportGroup)
 geocode_person = create_geocoder(Person)

--- a/agir/lib/tests/mixins.py
+++ b/agir/lib/tests/mixins.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from data_france.models import Commune
 from faker import Faker
 
+from agir.lib.models import LocationMixin
 from agir.events.models import Calendar, Event, OrganizerConfig, RSVP
 from agir.groups.models import SupportGroup, Membership, SupportGroupSubtype
 from agir.people.models import Person, PersonForm, PersonFormSubmission
@@ -54,6 +55,7 @@ def create_location():
     address = fake.street_address()
     coords = fake.local_latlng(country_code="FR", coords_only=True)
     return {
+        "coordinates_type": LocationMixin.COORDINATES_EXACT,
         "coordinates": Point(float(coords[1]), float(coords[0])),
         "location_name": address,
         "location_address": address,


### PR DESCRIPTION
- Refacto de ActivityCard
- migration des tâches `geocode_event` et `geocode_support_group`
- Création d'une activité pour les managers des groupes/événements dont la géolocalisation a échoué