### PR TITLE
Trigger accepted-invitation-member activity creation

### DIFF
--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.js
@@ -21,6 +21,7 @@ const RequiredActionCard = (props) => {
     event,
     supportGroup,
     individual,
+    meta,
     onDismiss,
     routes,
   } = props;
@@ -58,7 +59,7 @@ const RequiredActionCard = (props) => {
           iconName="mail"
           confirmLabel="Rejoindre"
           dismissLabel="Décliner"
-          onConfirm={supportGroup.url}
+          onConfirm={(meta && meta.joinUrl) || supportGroup.url}
           onDismiss={handleDismiss}
           text={
             <>
@@ -200,6 +201,9 @@ RequiredActionCard.propTypes = {
   individual: PropTypes.shape({
     firstName: PropTypes.string,
     email: PropTypes.string,
+  }),
+  meta: PropTypes.shape({
+    joinUrl: PropTypes.string,
   }),
   onDismiss: PropTypes.func,
   routes: PropTypes.object,

--- a/agir/activity/models.py
+++ b/agir/activity/models.py
@@ -19,10 +19,10 @@ class Activity(TimeStampedModel):
     TYPE_CANCELLED_EVENT = "cancelled-event"
     TYPE_REFERRAL = "referral-accepted"
     TYPE_GROUP_CREATION_CONFIRMATION = "group-creation-confirmation"
+    TYPE_ACCEPTED_INVITATION_MEMBER = "accepted-invitation-member"
     # TODO
     TYPE_GROUP_COORGANIZATION_INFO = "group-coorganization-info"
     TYPE_NEW_EVENT_AROUNDME = "new-event-aroundme"
-    TYPE_ACCEPTED_INVITATION_MEMBER = "accepted-invitation-member"
     TYPE_GROUP_COORGANIZATION_ACCEPTED = "group-coorganization-accepted"
     TYPE_WAITING_LOCATION_EVENT = "waiting-location-event"
     TYPE_GROUP_COORGANIZATION_INVITE = "group-coorganization-invite"

--- a/agir/groups/forms.py
+++ b/agir/groups/forms.py
@@ -15,6 +15,7 @@ from agir.groups.tasks import (
     send_external_join_confirmation,
     invite_to_group,
     create_group_creation_confirmation_activity,
+    create_accepted_invitation_member_activity,
 )
 from agir.lib.form_components import *
 from agir.lib.form_mixins import (
@@ -384,6 +385,10 @@ class InvitationWithSubscriptionConfirmationForm(forms.Form):
         )
 
         if cleaned_data.get("join_support_group"):
-            Membership.objects.create(person=p, supportgroup=self.group)
+            membership, created = Membership.objects.get_or_create(
+                supportgroup=self.group, person=p
+            )
+            if created:
+                create_accepted_invitation_member_activity.delay(membership.pk)
 
         return p

--- a/agir/groups/tests/test_tasks.py
+++ b/agir/groups/tests/test_tasks.py
@@ -1,4 +1,5 @@
 from django.core import mail
+from django.db.models import Q
 from django.shortcuts import reverse as dj_reverse
 from django.test import TestCase
 from django.utils import timezone
@@ -154,3 +155,39 @@ class NotificationTasksTestCase(TestCase):
             self.assertCountEqual(
                 a.meta["changed_data"], ["name", "contact_name", "description"]
             )
+
+    def test_create_accepted_invitation_member_activity(self):
+        supportgroup = self.group
+
+        new_member = Person.objects.create_insoumise("invited@group.member")
+        new_membership = Membership.objects.create(
+            supportgroup=supportgroup, person=new_member
+        )
+
+        managers_filter = (
+            Q(membership_type__gte=Membership.MEMBERSHIP_TYPE_MANAGER)
+        ) & Q(notifications_enabled=True)
+        managing_membership = supportgroup.memberships.filter(managers_filter)
+        managing_membership_recipients = [
+            membership.person for membership in managing_membership
+        ]
+
+        old_activity_count = Activity.objects.filter(
+            type=Activity.TYPE_ACCEPTED_INVITATION_MEMBER,
+            recipient__in=managing_membership_recipients,
+            supportgroup=supportgroup,
+            individual=new_member,
+        ).count()
+
+        tasks.create_accepted_invitation_member_activity(new_membership.pk)
+
+        new_activity_count = Activity.objects.filter(
+            type=Activity.TYPE_ACCEPTED_INVITATION_MEMBER,
+            recipient__in=managing_membership_recipients,
+            supportgroup=supportgroup,
+            individual=new_member,
+        ).count()
+
+        self.assertEqual(
+            new_activity_count, old_activity_count + managing_membership.count()
+        )

--- a/agir/groups/views/management_views.py
+++ b/agir/groups/views/management_views.py
@@ -40,7 +40,10 @@ from agir.groups.forms import (
     InvitationWithSubscriptionConfirmationForm,
 )
 from agir.groups.models import SupportGroup, Membership, SupportGroupSubtype
-from agir.groups.tasks import send_abuse_report_message
+from agir.groups.tasks import (
+    send_abuse_report_message,
+    create_accepted_invitation_member_activity,
+)
 from agir.lib.export import dict_to_camelcase
 from agir.lib.http import add_query_params_to_url
 from agir.people.models import Person
@@ -411,6 +414,7 @@ class InvitationConfirmationView(VerifyLinkSignatureMixin, View):
         )
 
         if created:
+            create_accepted_invitation_member_activity.delay(membership.pk)
             messages.add_message(
                 request,
                 messages.SUCCESS,

--- a/agir/groups/views/public_views.py
+++ b/agir/groups/views/public_views.py
@@ -228,7 +228,7 @@ class ExternalJoinSupportGroupView(ConfirmSubscriptionView, FormView, DetailView
             request=self.request,
             level=messages.INFO,
             message=_(
-                "Un email vous a été envoyé. Merrci de cliquer sur le "
+                "Un email vous a été envoyé. Merci de cliquer sur le "
                 "lien qu'il contient pour confirmer."
             ),
         )


### PR DESCRIPTION
- Ajout d'une tâche pour créer une activity de type `accepted-invitation-member`
- Fix de l'activity card `group-invitiation` pour utiliser l'URL d'invitation (enregistré dans le `meta` de l'activité) au lieu de l'URL de la page publique du groupe