### PR TITLE
Archive required activity cards

### DIFF
--- a/agir/activity/actions.py
+++ b/agir/activity/actions.py
@@ -15,20 +15,6 @@ def get_activity(person):
         )[:40]
     )
 
-
-def get_serialized_activity(request):
-    if hasattr(request.user, "person"):
-        person = request.user.person
-        activities = get_activity(person)
-
-        activity_serializer = ActivitySerializer(
-            instance=activities, many=True, context={"request": request}
-        )
-        return activity_serializer.data
-
-    return []
-
-
 def get_required_action_activity(person):
     required_action_activities = (
         Activity.objects.required_action()
@@ -50,20 +36,6 @@ def get_required_action_activity(person):
         pk__in=[a.pk for a in unread_required_action_activities]
         + [a.pk for a in read_required_action_activities]
     ).order_by("-created")
-
-
-def get_serialized_required_action_activity(request):
-    if hasattr(request.user, "person"):
-        person = request.user.person
-        activities = get_required_action_activity(person)
-
-        activity_serializer = ActivitySerializer(
-            instance=activities, many=True, context={"request": request}
-        )
-        return activity_serializer.data
-
-    return []
-
 
 def get_announcements(person=None):
     today = timezone.now()
@@ -92,13 +64,3 @@ def get_announcements(person=None):
         ]
     else:
         return announcements.filter(segment__isnull=True)
-
-
-def get_serialized_announcements(request):
-    person = getattr(request.user, "person", None)
-    announcements = get_announcements(person)
-
-    serializer = AnnouncementSerializer(
-        instance=announcements, many=True, context={"request": request}
-    )
-    return serializer.data

--- a/agir/activity/actions.py
+++ b/agir/activity/actions.py
@@ -6,7 +6,7 @@ from .serializers import ActivitySerializer, AnnouncementSerializer
 from ..events.models import Event
 
 
-def get_activity(person):
+def get_activities(person):
     return (
         Activity.objects.unrequired_action()
         .filter(recipient=person)
@@ -15,7 +15,7 @@ def get_activity(person):
         )[:40]
     )
 
-def get_required_action_activity(person):
+def get_required_action_activities(person):
     required_action_activities = (
         Activity.objects.required_action()
         .filter(recipient=person)

--- a/agir/activity/actions.py
+++ b/agir/activity/actions.py
@@ -8,16 +8,17 @@ from ..events.models import Event
 
 def get_activities(person):
     return (
-        Activity.objects.unrequired_action()
+        Activity.objects.without_required_action()
         .filter(recipient=person)
         .prefetch_related(
             Prefetch("event", Event.objects.with_serializer_prefetch(person),)
         )[:40]
     )
 
+
 def get_required_action_activities(person):
     required_action_activities = (
-        Activity.objects.required_action()
+        Activity.objects.with_required_action()
         .filter(recipient=person)
         .prefetch_related(
             Prefetch("event", Event.objects.with_serializer_prefetch(person),)
@@ -36,6 +37,7 @@ def get_required_action_activities(person):
         pk__in=[a.pk for a in unread_required_action_activities]
         + [a.pk for a in read_required_action_activities]
     ).order_by("-created")
+
 
 def get_announcements(person=None):
     today = timezone.now()

--- a/agir/activity/components/common/Activities.js
+++ b/agir/activity/components/common/Activities.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
+import { useTransition, animated } from "react-spring";
 import styled from "styled-components";
 
 import style from "@agir/front/genericComponents/_variables.scss";
@@ -61,18 +62,21 @@ export const StyledList = styled.ul`
 
 export const Activities = (props) => {
   const { activities, routes, onDismiss, CardComponent } = props;
+
+  const transitions = useTransition(activities, ({ id }) => id, {
+    initial: { transform: "translate3d(0,0,0)" },
+    enter: { opacity: 1, maxHeight: "300px" },
+    leave: { opacity: 0, maxHeight: "0px" },
+  });
+
   return (
     <article>
       {activities.length > 0 ? (
         <StyledList type="activities">
-          {activities.map((activity) => (
-            <li key={activity.id}>
-              <CardComponent
-                onDismiss={onDismiss}
-                routes={routes}
-                {...activity}
-              />
-            </li>
+          {transitions.map(({ item, key, props }) => (
+            <animated.li key={key} style={props}>
+              <CardComponent onDismiss={onDismiss} routes={routes} {...item} />
+            </animated.li>
           ))}
         </StyledList>
       ) : (

--- a/agir/activity/components/common/helpers.js
+++ b/agir/activity/components/common/helpers.js
@@ -24,6 +24,18 @@ export const getUnreadCount = (data) => {
   return getUnread(data).length;
 };
 
+export const getUninteracted = (data) => {
+  return Array.isArray(data)
+    ? data.filter(
+        (activity) => activity.status !== activityStatus.STATUS_INTERACTED
+      )
+    : [];
+};
+
+export const getUninteractedCount = (data) => {
+  return getUninteracted(data).length;
+};
+
 export const updateActivityStatus = async (
   id,
   status = activityStatus.STATUS_INTERACTED

--- a/agir/activity/components/common/helpers.js
+++ b/agir/activity/components/common/helpers.js
@@ -12,37 +12,6 @@ export const activityStatus = {
   STATUS_INTERACTED: "I",
 };
 
-export const requiredActivityTypes = [
-  "waiting-payment",
-  "group-invitation",
-  "new-member",
-  "waiting-location-group",
-  "group-coorganization-invite",
-  "waiting-location-event",
-  "group-creation-confirmation",
-  "group-membership-limit-reminder",
-];
-
-export const parseActivities = (data, dismissed = []) => {
-  const parsedActivities = {
-    required: [],
-    unrequired: [],
-  };
-  if (Array.isArray(data) && data.length > 0) {
-    data.forEach((activity) => {
-      if (dismissed.includes(activity.id)) {
-        return;
-      }
-      if (requiredActivityTypes.includes(activity.type)) {
-        parsedActivities.required.push(activity);
-      } else {
-        parsedActivities.unrequired.push(activity);
-      }
-    });
-  }
-  return parsedActivities;
-};
-
 export const getUnread = (data) => {
   return Array.isArray(data)
     ? data.filter(
@@ -55,7 +24,7 @@ export const getUnreadCount = (data) => {
   return getUnread(data).length;
 };
 
-export const dismissActivity = async (
+export const updateActivityStatus = async (
   id,
   status = activityStatus.STATUS_INTERACTED
 ) => {
@@ -79,7 +48,13 @@ export const dismissActivity = async (
   return result;
 };
 
-export const setActivitiesAsRead = async (ids = []) => {
+export const setActivityAsInteracted = (id) =>
+  updateActivityStatus(id, activityStatus.STATUS_INTERACTED);
+
+export const setActivityAsDisplayed = (id) =>
+  updateActivityStatus(id, activityStatus.STATUS_DISPLAYED);
+
+export const setActivitiesAsDisplayed = async (ids = []) => {
   let result = false;
   if (!Array.isArray(ids) || ids.length === 0) {
     return result;

--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.js
@@ -20,10 +20,6 @@ const GroupMembershipLimitReminderRequiredActionCard = (props) => {
   } = props;
   const { membershipCount, membershipLimitNotificationStep } = meta;
 
-  if (!membershipCount || typeof membershipLimitNotificationStep !== "number") {
-    return null;
-  }
-
   switch (membershipLimitNotificationStep) {
     case 0:
       return (
@@ -122,8 +118,8 @@ const GroupMembershipLimitReminderRequiredActionCard = (props) => {
           text={
             <>
               <strong>
-                Bravo, vous êtes maintenant {membershipCount} dans votre
-                équipe&nbsp;!
+                Bravo, vous êtes maintenant {membershipCount || "nombreux·ses"}{" "}
+                dans votre équipe&nbsp;!
               </strong>
               <br />
               <a href={supportGroup.url}>{supportGroup.name}</a> a atteint le

--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.js
@@ -215,7 +215,7 @@ const RequiredActionCard = (props) => {
           iconName="alert-circle"
           confirmLabel="Payer"
           dismissLabel="Voir l'événement"
-          onConfirm={event.routes.rsvp}
+          onConfirm={dismissed ? null : event.routes.rsvp}
           dismissed={dismissed}
           timestamp={timestamp}
           text={

--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.js
@@ -1,26 +1,16 @@
 import PropTypes from "prop-types";
 import React, { useCallback, useMemo } from "react";
+import { useHistory } from "react-router-dom";
 
 import { routeConfig } from "@agir/front/app/routes.config";
 import Link from "@agir/front/app/Link";
 import ActionCard from "@agir/front/genericComponents/ActionCard";
 import useCopyToClipboard from "@agir/front/genericComponents/useCopyToClipboard";
 
-import { useHistory } from "react-router-dom";
-
-export const requiredActionTypes = [
-  "waiting-payment",
-  "group-invitation",
-  "new-member",
-  "waiting-location-group",
-  "group-coorganization-invite",
-  "waiting-location-event",
-  "group-creation-confirmation",
-  "group-membership-limit-reminder",
-];
+import { activityStatus } from "@agir/activity/common/helpers";
 
 const GroupMembershipLimitReminderRequiredActionCard = (props) => {
-  const { supportGroup, meta = {}, routes, onDismiss } = props;
+  const { supportGroup, meta = {}, routes, onDismiss, dismissed } = props;
   const { membershipCount, membershipLimitNotificationStep } = meta;
 
   if (!membershipCount || typeof membershipLimitNotificationStep !== "number") {
@@ -38,6 +28,7 @@ const GroupMembershipLimitReminderRequiredActionCard = (props) => {
             supportGroup.routes && supportGroup.routes.membershipTransfer
           }
           onDismiss={onDismiss}
+          dismissed={dismissed}
           text={
             <>
               <strong>
@@ -64,6 +55,7 @@ const GroupMembershipLimitReminderRequiredActionCard = (props) => {
             supportGroup.routes && supportGroup.routes.membershipTransfer
           }
           onDismiss={onDismiss}
+          dismissed={dismissed}
           text={
             <>
               <strong>Votre équipe est trop nombreuse</strong>
@@ -89,6 +81,7 @@ const GroupMembershipLimitReminderRequiredActionCard = (props) => {
             supportGroup.routes && supportGroup.routes.membershipTransfer
           }
           onDismiss={onDismiss}
+          dismissed={dismissed}
           text={
             <>
               <strong>
@@ -114,6 +107,7 @@ const GroupMembershipLimitReminderRequiredActionCard = (props) => {
           dismissLabel="Cacher"
           onConfirm={routes.groupTransferHelp}
           onDismiss={onDismiss}
+          dismissed={dismissed}
           text={
             <>
               <strong>
@@ -149,6 +143,7 @@ GroupMembershipLimitReminderRequiredActionCard.propTypes = {
     charteEquipes: PropTypes.string.isRequired,
   }).isRequired,
   onDismiss: PropTypes.func,
+  dismissed: PropTypes.bool,
 };
 
 const RequiredActionCard = (props) => {
@@ -160,6 +155,7 @@ const RequiredActionCard = (props) => {
     individual,
     meta,
     onDismiss,
+    status,
     routes,
   } = props;
 
@@ -195,6 +191,10 @@ const RequiredActionCard = (props) => {
       history.push(routeConfig.eventDetails.getLink({ eventPk: event.id }));
   }, [event, history]);
 
+  const dismissed = useMemo(() => status === activityStatus.STATUS_INTERACTED, [
+    status,
+  ]);
+
   switch (type) {
     case "waiting-payment": {
       return (
@@ -204,6 +204,7 @@ const RequiredActionCard = (props) => {
           dismissLabel="Voir l'événement"
           onConfirm={event.routes.rsvp}
           onDismiss={goToEventDetails}
+          dismissed={dismissed}
           text={
             <>
               Vous n'avez pas encore réglé votre place pour l'événément :{" "}
@@ -221,6 +222,7 @@ const RequiredActionCard = (props) => {
           dismissLabel="Décliner"
           onConfirm={(meta && meta.joinUrl) || supportGroup.url}
           onDismiss={handleDismiss}
+          dismissed={dismissed}
           text={
             <>
               Vous avez été invité-e à rejoindre le groupe :{" "}
@@ -238,6 +240,7 @@ const RequiredActionCard = (props) => {
           dismissLabel="C'est fait"
           onConfirm={copyEmail}
           onDismiss={handleDismiss}
+          dismissed={dismissed}
           disabled={isEmailCopied}
           text={
             <>
@@ -256,6 +259,7 @@ const RequiredActionCard = (props) => {
           confirmLabel="Mettre à jour"
           onConfirm={supportGroup.url}
           onDismiss={handleDismiss}
+          dismissed={dismissed}
           text={
             <>
               Précisez la localisation de votre groupe{" "}
@@ -273,6 +277,7 @@ const RequiredActionCard = (props) => {
           dismissLabel="Décliner"
           onConfirm={goToEventDetails}
           onDismiss={handleDismiss}
+          dismissed={dismissed}
           text={
             <>
               <strong>{props.individual.firstName || "Quelqu'un"}</strong> a
@@ -291,6 +296,7 @@ const RequiredActionCard = (props) => {
           confirmLabel="Mettre à jour"
           onConfirm={event.routes.manage}
           onDismiss={handleDismiss}
+          dismissed={dismissed}
           text={<>Précisez la localisation de votre événement :{Event}</>}
         />
       );
@@ -303,6 +309,7 @@ const RequiredActionCard = (props) => {
           dismissLabel="C'est fait"
           onConfirm={routes && routes.newGroupHelp}
           onDismiss={handleDismiss}
+          dismissed={dismissed}
           text={
             <>
               <a href={supportGroup.url}>{supportGroup.name}</a> est en ligne !
@@ -330,6 +337,7 @@ const RequiredActionCard = (props) => {
         <GroupMembershipLimitReminderRequiredActionCard
           {...props}
           onDismiss={handleDismiss}
+          dismissed={dismissed}
         />
       );
     }
@@ -368,6 +376,7 @@ RequiredActionCard.propTypes = {
     email: PropTypes.string,
   }),
   onDismiss: PropTypes.func,
+  status: PropTypes.oneOf(Object.values(activityStatus)),
   meta: PropTypes.object,
   routes: PropTypes.object,
 };

--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.js
@@ -173,8 +173,8 @@ const RequiredActionCard = (props) => {
   } = props;
 
   const handleDismiss = useCallback(() => {
-    onDismiss(id);
-  }, [id, onDismiss]);
+    onDismiss(id, status);
+  }, [id, status, onDismiss]);
 
   const [isEmailCopied, copyEmail] = useCopyToClipboard(
     (individual && individual.email) || "",
@@ -216,7 +216,6 @@ const RequiredActionCard = (props) => {
           confirmLabel="Payer"
           dismissLabel="Voir l'événement"
           onConfirm={event.routes.rsvp}
-          onDismiss={goToEventDetails}
           dismissed={dismissed}
           timestamp={timestamp}
           text={

--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.js
@@ -10,7 +10,14 @@ import useCopyToClipboard from "@agir/front/genericComponents/useCopyToClipboard
 import { activityStatus } from "@agir/activity/common/helpers";
 
 const GroupMembershipLimitReminderRequiredActionCard = (props) => {
-  const { supportGroup, meta = {}, routes, onDismiss, dismissed } = props;
+  const {
+    supportGroup,
+    meta = {},
+    routes,
+    onDismiss,
+    dismissed,
+    timestamp,
+  } = props;
   const { membershipCount, membershipLimitNotificationStep } = meta;
 
   if (!membershipCount || typeof membershipLimitNotificationStep !== "number") {
@@ -29,6 +36,7 @@ const GroupMembershipLimitReminderRequiredActionCard = (props) => {
           }
           onDismiss={onDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
           text={
             <>
               <strong>
@@ -56,6 +64,7 @@ const GroupMembershipLimitReminderRequiredActionCard = (props) => {
           }
           onDismiss={onDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
           text={
             <>
               <strong>Votre équipe est trop nombreuse</strong>
@@ -82,6 +91,7 @@ const GroupMembershipLimitReminderRequiredActionCard = (props) => {
           }
           onDismiss={onDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
           text={
             <>
               <strong>
@@ -108,6 +118,7 @@ const GroupMembershipLimitReminderRequiredActionCard = (props) => {
           onConfirm={routes.groupTransferHelp}
           onDismiss={onDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
           text={
             <>
               <strong>
@@ -144,6 +155,7 @@ GroupMembershipLimitReminderRequiredActionCard.propTypes = {
   }).isRequired,
   onDismiss: PropTypes.func,
   dismissed: PropTypes.bool,
+  timestamp: PropTypes.string,
 };
 
 const RequiredActionCard = (props) => {
@@ -157,6 +169,7 @@ const RequiredActionCard = (props) => {
     onDismiss,
     status,
     routes,
+    timestamp,
   } = props;
 
   const handleDismiss = useCallback(() => {
@@ -205,6 +218,7 @@ const RequiredActionCard = (props) => {
           onConfirm={event.routes.rsvp}
           onDismiss={goToEventDetails}
           dismissed={dismissed}
+          timestamp={timestamp}
           text={
             <>
               Vous n'avez pas encore réglé votre place pour l'événément :{" "}
@@ -223,6 +237,7 @@ const RequiredActionCard = (props) => {
           onConfirm={(meta && meta.joinUrl) || supportGroup.url}
           onDismiss={handleDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
           text={
             <>
               Vous avez été invité-e à rejoindre le groupe :{" "}
@@ -241,6 +256,7 @@ const RequiredActionCard = (props) => {
           onConfirm={copyEmail}
           onDismiss={handleDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
           disabled={isEmailCopied}
           text={
             <>
@@ -260,6 +276,7 @@ const RequiredActionCard = (props) => {
           onConfirm={supportGroup.url}
           onDismiss={handleDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
           text={
             <>
               Précisez la localisation de votre groupe{" "}
@@ -278,6 +295,7 @@ const RequiredActionCard = (props) => {
           onConfirm={goToEventDetails}
           onDismiss={handleDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
           text={
             <>
               <strong>{props.individual.firstName || "Quelqu'un"}</strong> a
@@ -297,6 +315,7 @@ const RequiredActionCard = (props) => {
           onConfirm={event.routes.manage}
           onDismiss={handleDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
           text={<>Précisez la localisation de votre événement :{Event}</>}
         />
       );
@@ -310,6 +329,7 @@ const RequiredActionCard = (props) => {
           onConfirm={routes && routes.newGroupHelp}
           onDismiss={handleDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
           text={
             <>
               <a href={supportGroup.url}>{supportGroup.name}</a> est en ligne !
@@ -338,6 +358,7 @@ const RequiredActionCard = (props) => {
           {...props}
           onDismiss={handleDismiss}
           dismissed={dismissed}
+          timestamp={timestamp}
         />
       );
     }
@@ -379,5 +400,6 @@ RequiredActionCard.propTypes = {
   status: PropTypes.oneOf(Object.values(activityStatus)),
   meta: PropTypes.object,
   routes: PropTypes.object,
+  timestamp: PropTypes.string,
 };
 export default RequiredActionCard;

--- a/agir/activity/components/page__requiredActivities/RequiredActivityList.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActivityList.js
@@ -13,7 +13,10 @@ import {
   getRequiredActionActivities,
   getRoutes,
 } from "@agir/front/globalContext/reducers";
-import { dismissRequiredActionActivity } from "@agir/front/globalContext/actions";
+import {
+  dismissRequiredActionActivity,
+  undoRequiredActionActivityDismissal,
+} from "@agir/front/globalContext/actions";
 import { activityStatus } from "@agir/activity/common/helpers";
 
 import FilterTabs from "@agir/front/genericComponents/FilterTabs";
@@ -61,8 +64,12 @@ const RequiredActivityList = () => {
   }, []);
 
   const handleDismiss = useCallback(
-    async (id) => {
-      dispatch(dismissRequiredActionActivity(id));
+    async (id, status) => {
+      dispatch(
+        status !== activityStatus.STATUS_INTERACTED
+          ? dismissRequiredActionActivity(id)
+          : undoRequiredActionActivityDismissal(id)
+      );
     },
     [dispatch]
   );

--- a/agir/activity/components/page__requiredActivities/RequiredActivityList.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActivityList.js
@@ -1,5 +1,5 @@
+import React, { useCallback, useMemo, useState } from "react";
 import { Helmet } from "react-helmet";
-import React, { useCallback } from "react";
 import styled from "styled-components";
 
 import style from "@agir/front/genericComponents/_variables.scss";
@@ -14,7 +14,9 @@ import {
   getRoutes,
 } from "@agir/front/globalContext/reducers";
 import { dismissRequiredActionActivity } from "@agir/front/globalContext/actions";
+import { activityStatus } from "@agir/activity/common/helpers";
 
+import FilterTabs from "@agir/front/genericComponents/FilterTabs";
 import Activities from "@agir/activity/common/Activities";
 
 import {
@@ -53,12 +55,28 @@ const RequiredActivityList = () => {
   const routes = useSelector(getRoutes);
   const dispatch = useDispatch();
 
+  const [displayAll, setDisplayAll] = useState(false);
+  const toggleDisplayAll = useCallback((shouldDisplayAll) => {
+    setDisplayAll(Boolean(shouldDisplayAll));
+  }, []);
+
   const handleDismiss = useCallback(
     async (id) => {
       dispatch(dismissRequiredActionActivity(id));
     },
     [dispatch]
   );
+
+  const visibleActivities = useMemo(
+    () =>
+      activities.filter(
+        ({ status }) =>
+          displayAll || status !== activityStatus.STATUS_INTERACTED
+      ),
+    [displayAll, activities]
+  );
+
+  const tabs = useMemo(() => ["non traité", "voir tout"], []);
 
   return (
     <>
@@ -81,9 +99,14 @@ const RequiredActivityList = () => {
             </div>
           }
         >
+          <FilterTabs
+            style={{ marginTop: "2rem", marginBottom: "1rem" }}
+            tabs={tabs}
+            onTabChange={toggleDisplayAll}
+          />
           <Activities
             CardComponent={RequiredActionCard}
-            activities={activities}
+            activities={visibleActivities}
             onDismiss={handleDismiss}
             routes={routes}
           />

--- a/agir/activity/components/page__requiredActivities/RequiredActivityList.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActivityList.js
@@ -11,13 +11,14 @@ import {
 import {
   getIsSessionLoaded,
   getRequiredActionActivities,
+  getRequiredActionActivityCount,
   getRoutes,
 } from "@agir/front/globalContext/reducers";
 import {
   dismissRequiredActionActivity,
   undoRequiredActionActivityDismissal,
 } from "@agir/front/globalContext/actions";
-import { activityStatus } from "@agir/activity/common/helpers";
+import { activityStatus, getUninteracted } from "@agir/activity/common/helpers";
 
 import FilterTabs from "@agir/front/genericComponents/FilterTabs";
 import Activities from "@agir/activity/common/Activities";
@@ -55,6 +56,7 @@ const Counter = styled.span`
 const RequiredActivityList = () => {
   const isSessionLoaded = useSelector(getIsSessionLoaded);
   const activities = useSelector(getRequiredActionActivities);
+  const uninteractedCount = useSelector(getRequiredActionActivityCount);
   const routes = useSelector(getRoutes);
   const dispatch = useDispatch();
 
@@ -75,15 +77,13 @@ const RequiredActivityList = () => {
   );
 
   const visibleActivities = useMemo(
-    () =>
-      activities.filter(
-        ({ status }) =>
-          displayAll || status !== activityStatus.STATUS_INTERACTED
-      ),
+    () => (displayAll ? activities : getUninteracted(activities)),
     [displayAll, activities]
   );
 
   const tabs = useMemo(() => ["non traité", "voir tout"], []);
+
+  visibleActivities.forEach((a) => console.log(a.id, a.type, a.status));
 
   return (
     <>
@@ -92,7 +92,7 @@ const RequiredActivityList = () => {
       </Helmet>
       <Page>
         <LayoutTitle>
-          {activities.length ? <Counter>{activities.length}</Counter> : null}À
+          {uninteractedCount ? <Counter>{uninteractedCount}</Counter> : null}À
           faire
         </LayoutTitle>
         <LayoutSubtitle>

--- a/agir/activity/components/page__requiredActivities/RequiredActivityList.stories.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActivityList.stories.js
@@ -8,26 +8,42 @@ import * as RequiredActionCardStories from "./RequiredActionCard.stories";
 export default {
   component: Activities,
   title: "Activities/RequiredActivityList",
-  argTypes: {},
 };
 
 const Template = (args) => {
-  return <Activities {...args} />;
+  const [activities, setActivites] = React.useState(args.activities);
+
+  const handleDismiss = React.useCallback((id) => {
+    setActivites((state) => state.filter((activity) => activity.id !== id));
+  }, []);
+
+  return (
+    <>
+      <button
+        disabled={activities.length >= args.activities.length}
+        onClick={() => setActivites(args.activities)}
+      >
+        Reset activities
+      </button>
+      <Activities
+        CardComponent={RequiredActionCard}
+        activities={activities}
+        onDismiss={handleDismiss}
+      />
+    </>
+  );
 };
+
+const initialActivities = Object.values(RequiredActionCardStories)
+  .map(({ args }, i) => ({ ...args, id: i }))
+  .filter(Boolean);
 
 export const Default = Template.bind({});
 Default.args = {
-  activities: [
-    ...Object.values(RequiredActionCardStories)
-      .map(({ args }) => args)
-      .filter(Boolean),
-  ],
-  onDismiss: () => {},
-  CardComponent: RequiredActionCard,
+  activities: initialActivities,
 };
 
 export const Empty = Template.bind({});
 Empty.args = {
   activities: [],
-  onDismiss: () => {},
 };

--- a/agir/activity/models.py
+++ b/agir/activity/models.py
@@ -11,10 +11,10 @@ class ActivityQuerySet(models.QuerySet):
     def displayed(self):
         return self.filter(type__in=Activity.DISPLAYED_TYPES)
 
-    def required_action(self):
+    def with_required_action(self):
         return self.displayed().filter(type__in=Activity.REQUIRED_ACTION_ACTIVITY_TYPES)
 
-    def unrequired_action(self):
+    def without_required_action(self):
         return self.displayed().exclude(
             type__in=Activity.REQUIRED_ACTION_ACTIVITY_TYPES
         )

--- a/agir/activity/models.py
+++ b/agir/activity/models.py
@@ -7,6 +7,19 @@ from stdimage.validators import MinSizeValidator
 from agir.lib.models import TimeStampedModel, DescriptionField
 
 
+class ActivityQuerySet(models.QuerySet):
+    def displayed(self):
+        return self.filter(type__in=Activity.DISPLAYED_TYPES)
+
+    def required_action(self):
+        return self.displayed().filter(type__in=Activity.REQUIRED_ACTION_ACTIVITY_TYPES)
+
+    def unrequired_action(self):
+        return self.displayed().exclude(
+            type__in=Activity.REQUIRED_ACTION_ACTIVITY_TYPES
+        )
+
+
 class Activity(TimeStampedModel):
     # Avec affichage d'une notification
     TYPE_GROUP_INVITATION = "group-invitation"
@@ -58,6 +71,17 @@ class Activity(TimeStampedModel):
         TYPE_NEW_MEMBERS_THROUGH_TRANSFER,
     )
 
+    REQUIRED_ACTION_ACTIVITY_TYPES = (
+        TYPE_WAITING_PAYMENT,
+        TYPE_GROUP_INVITATION,
+        TYPE_NEW_MEMBER,
+        TYPE_WAITING_LOCATION_GROUP,
+        TYPE_GROUP_COORGANIZATION_INVITE,
+        TYPE_WAITING_LOCATION_EVENT,
+        TYPE_GROUP_CREATION_CONFIRMATION,
+        TYPE_GROUP_MEMBERSHIP_LIMIT_REMINDER,
+    )
+
     TYPE_CHOICES = (
         (TYPE_WAITING_PAYMENT, "Paiement en attente"),
         (TYPE_GROUP_INVITATION, "Invitation à un groupe"),
@@ -101,6 +125,8 @@ class Activity(TimeStampedModel):
         (STATUS_DISPLAYED, "Présentée au destinataire"),
         (STATUS_INTERACTED, "Le destinataire a interagi avec"),
     )  # attention : l'ordre croissant par niveau d'interaction est important
+
+    objects = ActivityQuerySet.as_manager()
 
     timestamp = models.DateTimeField(
         verbose_name="Date de la notification", null=False, default=timezone.now

--- a/agir/authentication/serializers.py
+++ b/agir/authentication/serializers.py
@@ -3,8 +3,8 @@ from django.middleware.csrf import get_token
 from rest_framework import serializers
 
 from agir.activity.actions import (
-    get_activity,
-    get_required_action_activity,
+    get_activities,
+    get_required_action_activities,
     get_announcements,
 )
 from agir.activity.serializers import ActivitySerializer, AnnouncementSerializer
@@ -53,7 +53,7 @@ class SessionSerializer(serializers.Serializer):
         if request.user.is_authenticated and request.user.person is not None:
             return ActivitySerializer(
                 many=True,
-                instance=get_activity(request.user.person),
+                instance=get_activities(request.user.person),
                 context={"request": request},
             ).data
 
@@ -61,7 +61,7 @@ class SessionSerializer(serializers.Serializer):
         if request.user.is_authenticated and request.user.person is not None:
             return ActivitySerializer(
                 many=True,
-                instance=get_required_action_activity(request.user.person),
+                instance=get_required_action_activities(request.user.person),
                 context={"request": request},
             ).data
 

--- a/agir/authentication/serializers.py
+++ b/agir/authentication/serializers.py
@@ -2,7 +2,11 @@ from django.contrib import messages
 from django.middleware.csrf import get_token
 from rest_framework import serializers
 
-from agir.activity.actions import get_activity, get_announcements
+from agir.activity.actions import (
+    get_activity,
+    get_required_action_activity,
+    get_announcements,
+)
 from agir.activity.serializers import ActivitySerializer, AnnouncementSerializer
 
 
@@ -26,6 +30,9 @@ class SessionSerializer(serializers.Serializer):
     user = serializers.SerializerMethodField(method_name="get_user")
     toasts = serializers.SerializerMethodField(method_name="get_toasts")
     activities = serializers.SerializerMethodField(method_name="get_activities")
+    requiredActionActivities = serializers.SerializerMethodField(
+        method_name="get_required_action_activities"
+    )
     announcements = serializers.SerializerMethodField(method_name="get_announcements")
 
     def get_csrf_token(self, request):
@@ -47,6 +54,14 @@ class SessionSerializer(serializers.Serializer):
             return ActivitySerializer(
                 many=True,
                 instance=get_activity(request.user.person),
+                context={"request": request},
+            ).data
+
+    def get_required_action_activities(self, request):
+        if request.user.is_authenticated and request.user.person is not None:
+            return ActivitySerializer(
+                many=True,
+                instance=get_required_action_activity(request.user.person),
                 context={"request": request},
             ).data
 

--- a/agir/events/components/agendaPage/Agenda.js
+++ b/agir/events/components/agendaPage/Agenda.js
@@ -135,7 +135,8 @@ const otherEventConfig = {
   },
   GROUPS_TYPE: {
     label: "Dans mes groupes",
-    allowEmpty: (user) => Array.isArray(user.groups) && user.groups.length > 0,
+    allowEmpty: (user) =>
+      user && Array.isArray(user.groups) && user.groups.length > 0,
     filter: (events) =>
       events.filter(
         (event) =>

--- a/agir/front/components/genericComponents/ActionCard.js
+++ b/agir/front/components/genericComponents/ActionCard.js
@@ -19,6 +19,21 @@ const StyledFooter = styled.footer`
   display: flex;
   flex-flow: row nowrap;
 `;
+const StyledButton = styled(Button)`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  text-align: left;
+
+  &[disabled] {
+    cursor: default;
+  }
+
+  & + & {
+    margin-left: 0.5rem;
+  }
+`;
 
 const ActionCard = (props) => {
   const {
@@ -29,9 +44,10 @@ const ActionCard = (props) => {
     dismissLabel,
     onDismiss,
     disabled,
+    dismissed,
   } = props;
   return (
-    <Card type="alert">
+    <Card type={dismissed ? "alert_dismissed" : "alert"}>
       <Container style={{ width: "auto" }}>
         <Row justify="flex-start">
           <Column width="auto" collapse={0} style={{ padding: 0 }}>
@@ -61,13 +77,28 @@ const ActionCard = (props) => {
                 </Button>
               ) : null}
               {typeof onDismiss === "function" ? (
-                <Button onClick={onDismiss} small disabled={disabled}>
+                <StyledButton
+                  onClick={onDismiss}
+                  small
+                  disabled={disabled}
+                  color={dismissed ? "success" : "default"}
+                  icon={dismissed ? "x" : undefined}
+                  $hasTransition
+                >
                   {dismissLabel}
-                </Button>
+                </StyledButton>
               ) : typeof onDismiss === "string" ? (
-                <Button small as="a" href={onDismiss} disabled={disabled}>
+                <StyledButton
+                  small
+                  as="a"
+                  href={onDismiss}
+                  disabled={disabled}
+                  color={dismissed ? "success" : "default"}
+                  icon={dismissed ? "x" : undefined}
+                  $hasTransition
+                >
                   {dismissLabel}
-                </Button>
+                </StyledButton>
               ) : null}
             </StyledFooter>
           </Column>
@@ -85,10 +116,12 @@ ActionCard.propTypes = {
   dismissLabel: PropTypes.string,
   onDismiss: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   disabled: PropTypes.bool,
+  dismissed: PropTypes.bool,
 };
 ActionCard.defaultProps = {
   dismissLabel: "Cacher",
   disabled: false,
+  dismissed: false,
 };
 
 export default ActionCard;

--- a/agir/front/components/genericComponents/ActionCard.js
+++ b/agir/front/components/genericComponents/ActionCard.js
@@ -21,34 +21,26 @@ const StyledText = styled.p`
 const StyledFooter = styled.footer`
   display: flex;
   flex-flow: row nowrap;
-`;
 
-const StyledButton = styled.div`
   & > * {
     display: inline-flex;
-    ${({ active }) =>
-      !active
-        ? `
-        font-size: 0;
-        color: transparent;
-        padding: 0;
-        border-width: 0;
-        margin-left: -0.5rem;
-      `
-        : ""}
     align-items: center;
     justify-content: center;
     cursor: pointer;
     text-align: left;
-    transition: all 200ms ease-in-out;
+    transition: all 250ms ease-in-out;
 
     &[disabled] {
       cursor: default;
     }
-  }
 
-  & + & {
-    margin-left: 0.5rem;
+    &.inactive {
+      font-size: 0;
+      color: transparent;
+      padding: 0;
+      border-width: 0;
+      margin-left: -0.5rem;
+    }
   }
 `;
 
@@ -95,39 +87,34 @@ const ActionCard = (props) => {
             <StyledFooter>
               {(typeof onConfirm === "string" ||
                 typeof onConfirm === "function") && (
-                <StyledButton active={!dismissed}>
-                  <Button
-                    small
-                    as={typeof onConfirm === "string" ? "a" : undefined}
-                    onClick={
-                      typeof onConfirm === "function" ? onConfirm : undefined
-                    }
-                    href={typeof onConfirm === "string" ? onConfirm : undefined}
-                    disabled={disabled}
-                    color="secondary"
-                    $hasTransition
-                  >
-                    {confirmLabel}
-                  </Button>
-                </StyledButton>
+                <Button
+                  small
+                  as={typeof onConfirm === "string" ? "a" : undefined}
+                  onClick={
+                    typeof onConfirm === "function" ? onConfirm : undefined
+                  }
+                  href={typeof onConfirm === "string" ? onConfirm : undefined}
+                  disabled={disabled}
+                  className={dismissed ? "inactive" : ""}
+                  color="secondary"
+                >
+                  {confirmLabel}
+                </Button>
               )}
               {(typeof onDismiss === "string" ||
                 typeof onDismiss === "function") && (
-                <StyledButton active>
-                  <Button
-                    small
-                    as={typeof onDismiss === "string" ? "a" : undefined}
-                    onClick={
-                      typeof onDismiss === "function" ? onDismiss : undefined
-                    }
-                    href={typeof onDismiss === "string" ? onDismiss : undefined}
-                    disabled={disabled}
-                    color="default"
-                    $hasTransition
-                  >
-                    {dismissed ? "Marquer comme non traité" : dismissLabel}
-                  </Button>
-                </StyledButton>
+                <Button
+                  small
+                  as={typeof onDismiss === "string" ? "a" : undefined}
+                  onClick={
+                    typeof onDismiss === "function" ? onDismiss : undefined
+                  }
+                  href={typeof onDismiss === "string" ? onDismiss : undefined}
+                  disabled={disabled}
+                  color="default"
+                >
+                  {dismissed ? "Marquer comme non traité" : dismissLabel}
+                </Button>
               )}
             </StyledFooter>
           </Column>

--- a/agir/front/components/genericComponents/ActionCard.js
+++ b/agir/front/components/genericComponents/ActionCard.js
@@ -1,6 +1,8 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
+
+import { dateFromISOString, displayHumanDate } from "@agir/lib/utils/time";
 
 import { Container, Row, Column } from "@agir/front/genericComponents/grid";
 import Card from "@agir/front/genericComponents/Card";
@@ -45,7 +47,19 @@ const ActionCard = (props) => {
     onDismiss,
     disabled,
     dismissed,
+    timestamp,
   } = props;
+
+  const date = useMemo(
+    () =>
+      timestamp &&
+      displayHumanDate(dateFromISOString(timestamp))
+        .split("")
+        .map((ch, i) => (i ? ch : ch.toUpperCase()))
+        .join(""),
+    [timestamp]
+  );
+
   return (
     <Card type={dismissed ? "alert_dismissed" : "alert"}>
       <Container style={{ width: "auto" }}>
@@ -54,7 +68,11 @@ const ActionCard = (props) => {
             <FeatherIcon name={iconName} />
           </Column>
           <Column grow collapse={0}>
-            <StyledText>{text}</StyledText>
+            <StyledText>
+              {text}
+              <br />
+              <em>{date ? date : null}</em>
+            </StyledText>
             <StyledFooter>
               {typeof onConfirm === "function" ? (
                 <Button
@@ -117,6 +135,7 @@ ActionCard.propTypes = {
   onDismiss: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   disabled: PropTypes.bool,
   dismissed: PropTypes.bool,
+  timestamp: PropTypes.string,
 };
 ActionCard.defaultProps = {
   dismissLabel: "Cacher",

--- a/agir/front/components/genericComponents/ActionCard.js
+++ b/agir/front/components/genericComponents/ActionCard.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React, { useMemo } from "react";
 import styled from "styled-components";
 
+import style from "@agir/front/genericComponents/_variables.scss";
 import { dateFromISOString, displayHumanDate } from "@agir/lib/utils/time";
 
 import { Container, Row, Column } from "@agir/front/genericComponents/grid";
@@ -22,15 +23,28 @@ const StyledFooter = styled.footer`
   flex-flow: row nowrap;
 `;
 
-const StyledButton = styled(Button)`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  text-align: left;
+const StyledButton = styled.div`
+  & > * {
+    display: inline-flex;
+    ${({ active }) =>
+      !active
+        ? `
+        font-size: 0;
+        color: transparent;
+        padding: 0;
+        border-width: 0;
+        margin-left: -0.5rem;
+      `
+        : ""}
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    text-align: left;
+    transition: all 200ms ease-in-out;
 
-  &[disabled] {
-    cursor: default;
+    &[disabled] {
+      cursor: default;
+    }
   }
 
   & + & {
@@ -66,7 +80,11 @@ const ActionCard = (props) => {
       <Container style={{ width: "auto" }}>
         <Row justify="flex-start">
           <Column width="auto" collapse={0} style={{ padding: 0 }}>
-            <FeatherIcon name={iconName} />
+            {dismissed ? (
+              <FeatherIcon name="check-circle" color={style.green500} />
+            ) : (
+              <FeatherIcon name={iconName} />
+            )}
           </Column>
           <Column grow collapse={0}>
             <StyledText>
@@ -75,50 +93,42 @@ const ActionCard = (props) => {
               <em>{date ? date : null}</em>
             </StyledText>
             <StyledFooter>
-              {typeof onConfirm === "function" ? (
-                <Button
-                  onClick={onConfirm}
-                  small
-                  color="secondary"
-                  disabled={disabled}
-                >
-                  {confirmLabel}
-                </Button>
-              ) : typeof onConfirm === "string" ? (
-                <Button
-                  small
-                  color="secondary"
-                  as="a"
-                  href={onConfirm}
-                  disabled={disabled}
-                >
-                  {confirmLabel}
-                </Button>
-              ) : null}
-              {typeof onDismiss === "function" ? (
-                <StyledButton
-                  onClick={onDismiss}
-                  small
-                  disabled={disabled}
-                  color={dismissed ? "success" : "default"}
-                  icon={dismissed ? "x" : undefined}
-                  $hasTransition
-                >
-                  {dismissLabel}
+              {(typeof onConfirm === "string" ||
+                typeof onConfirm === "function") && (
+                <StyledButton active={!dismissed}>
+                  <Button
+                    small
+                    as={typeof onConfirm === "string" ? "a" : undefined}
+                    onClick={
+                      typeof onConfirm === "function" ? onConfirm : undefined
+                    }
+                    href={typeof onConfirm === "string" ? onConfirm : undefined}
+                    disabled={disabled}
+                    color="secondary"
+                    $hasTransition
+                  >
+                    {confirmLabel}
+                  </Button>
                 </StyledButton>
-              ) : typeof onDismiss === "string" ? (
-                <StyledButton
-                  small
-                  as="a"
-                  href={onDismiss}
-                  disabled={disabled}
-                  color={dismissed ? "success" : "default"}
-                  icon={dismissed ? "x" : undefined}
-                  $hasTransition
-                >
-                  {dismissLabel}
+              )}
+              {(typeof onDismiss === "string" ||
+                typeof onDismiss === "function") && (
+                <StyledButton active>
+                  <Button
+                    small
+                    as={typeof onDismiss === "string" ? "a" : undefined}
+                    onClick={
+                      typeof onDismiss === "function" ? onDismiss : undefined
+                    }
+                    href={typeof onDismiss === "string" ? onDismiss : undefined}
+                    disabled={disabled}
+                    color="default"
+                    $hasTransition
+                  >
+                    {dismissed ? "Marquer comme non traité" : dismissLabel}
+                  </Button>
                 </StyledButton>
-              ) : null}
+              )}
             </StyledFooter>
           </Column>
         </Row>

--- a/agir/front/components/genericComponents/ActionCard.js
+++ b/agir/front/components/genericComponents/ActionCard.js
@@ -21,6 +21,7 @@ const StyledFooter = styled.footer`
   display: flex;
   flex-flow: row nowrap;
 `;
+
 const StyledButton = styled(Button)`
   display: inline-flex;
   align-items: center;

--- a/agir/front/components/genericComponents/ActionCard.stories.js
+++ b/agir/front/components/genericComponents/ActionCard.stories.js
@@ -32,4 +32,5 @@ Default.args = {
   confirmLabel: "Mettre à jour",
   dismissLabel: "Cacher",
   dismissed: false,
+  timestamp: new Date().toISOString(),
 };

--- a/agir/front/components/genericComponents/ActionCard.stories.js
+++ b/agir/front/components/genericComponents/ActionCard.stories.js
@@ -15,7 +15,7 @@ const Template = (args) => {
   return (
     <div
       style={{
-        maxWidth: 396,
+        maxWidth: 500,
         margin: "10px auto",
       }}
     >

--- a/agir/front/components/genericComponents/ActionCard.stories.js
+++ b/agir/front/components/genericComponents/ActionCard.stories.js
@@ -31,4 +31,5 @@ Default.args = {
   iconName: "alert-circle",
   confirmLabel: "Mettre à jour",
   dismissLabel: "Cacher",
+  dismissed: false,
 };

--- a/agir/front/components/genericComponents/Button.js
+++ b/agir/front/components/genericComponents/Button.js
@@ -58,7 +58,8 @@ const buttonColors = {
  * Pour une raison obscure, lorsque la taille dédiée au contenu (telle que déterminée par min-height)
  */
 export const Button = styled.button.attrs(
-  ({ color, small, block, icon, as }) => ({
+  ({ color, small, block, icon, as, $hasTransition }) => ({
+    $hasTransition,
     $color: color,
     $small: small,
     $block: block,
@@ -98,6 +99,8 @@ export const Button = styled.button.attrs(
     return $background;
   }}}
   cursor: pointer;
+  ${({ $hasTransition }) =>
+    $hasTransition ? "transition: all 250ms ease-in;" : ""}
 
   & + & {
     margin-left: ${({ $block }) => ($block ? "0" : "0.5rem")};
@@ -172,6 +175,7 @@ Button.propTypes = {
   small: PropTypes.bool,
   block: PropTypes.bool,
   icon: PropTypes.string,
+  $hasTransition: PropTypes.bool,
 };
 
 Button.defaultProps = {

--- a/agir/front/components/genericComponents/Button.stories.js
+++ b/agir/front/components/genericComponents/Button.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import Button from "./Button";
+import Button, { buttonColors } from "./Button";
 import { allIcons } from "./FeatherIcon";
 import { Column, Row } from "@agir/front/genericComponents/grid";
 
@@ -11,7 +11,7 @@ export default {
     color: {
       control: {
         type: "select",
-        options: Button.colors,
+        options: Object.keys(buttonColors),
       },
     },
     icon: {
@@ -31,7 +31,12 @@ export default {
 const Template = (args) => <Button {...args} />;
 
 export const Default = Template.bind({});
-Default.args = { small: false, disabled: false, children: "Texte du bouton" };
+Default.args = {
+  small: false,
+  disabled: false,
+  children: "Texte du bouton",
+  $hasTransition: false,
+};
 
 export const PrimaryColor = Template.bind({});
 PrimaryColor.args = {
@@ -87,4 +92,26 @@ export const ButtonAndLink = (args) => (
 );
 ButtonAndLink.args = {
   ...Default.args,
+};
+
+export const WithTransition = (args) => {
+  const [state, setState] = React.useState(0);
+  const colors = React.useMemo(() => Object.keys(buttonColors), []);
+  const updateState = React.useCallback(() => {
+    setState((state) => state + 1);
+  }, []);
+  const color = React.useMemo(() => colors[state % colors.length], [
+    state,
+    colors,
+  ]);
+  const small = React.useMemo(
+    () => Boolean(Math.floor(state / colors.length) % 2),
+    [state, colors]
+  );
+
+  return <Button {...args} color={color} small={small} onClick={updateState} />;
+};
+WithTransition.args = {
+  ...Default.args,
+  $hasTransition: true,
 };

--- a/agir/front/components/genericComponents/Card.js
+++ b/agir/front/components/genericComponents/Card.js
@@ -11,7 +11,12 @@ const cardTypes = {
     background: style.primary100,
   },
   alert: {
-    background: `linear-gradient(90deg, ${style.black1000} 0, ${style.black1000} 3px, ${style.white} 3px)`,
+    backgroundImage: `linear-gradient(90deg, transparent 0, transparent 3px, ${style.white} 3px)`,
+    backgroundColor: style.black1000,
+  },
+  alert_dismissed: {
+    backgroundImage: `linear-gradient(90deg, transparent 0, transparent 3px, ${style.white} 3px)`,
+    backgroundColor: style.white,
   },
 };
 
@@ -19,6 +24,14 @@ const Card = styled.div`
   background: ${({ type }) =>
     type && cardTypes[type] && cardTypes[type].background
       ? cardTypes[type].background
+      : cardTypes.default.background};
+  background-image: ${({ type }) =>
+    type && cardTypes[type] && cardTypes[type].backgroundImage
+      ? cardTypes[type].backgroundImage
+      : "none"};
+  background-color: ${({ type }) =>
+    type && cardTypes[type] && cardTypes[type].backgroundColor
+      ? cardTypes[type].backgroundColor
       : cardTypes.default.background};
   padding: 1.5rem;
   border-radius: ${({ type }) =>
@@ -29,7 +42,7 @@ const Card = styled.div`
   cursor: ${({ onClick }) => (onClick ? "pointer" : "default")};
   border: 1px solid;
   border-color: ${style.black100};
-  transition: border-color 300ms;
+  transition: border-color, background-color 300ms;
 
   &:hover {
     ${({ onClick }) =>

--- a/agir/front/components/genericComponents/FilterTabs.js
+++ b/agir/front/components/genericComponents/FilterTabs.js
@@ -81,7 +81,7 @@ const TabListWrapper = styled.div`
   }
 `;
 
-const FilterTabs = ({ tabs, onTabChange }) => {
+const FilterTabs = ({ tabs, onTabChange, style }) => {
   const [tab, setTab] = useState(0);
 
   if (tabs.length === 0) {
@@ -89,7 +89,7 @@ const FilterTabs = ({ tabs, onTabChange }) => {
   }
 
   return (
-    <TabListWrapper>
+    <TabListWrapper style={style}>
       <TabList>
         {tabs.map((label, index) => (
           <Tab
@@ -110,4 +110,5 @@ export default FilterTabs;
 FilterTabs.propTypes = {
   tabs: PropTypes.arrayOf(PropTypes.string).isRequired,
   onTabChange: PropTypes.func.isRequired,
+  style: PropTypes.object,
 };

--- a/agir/front/components/globalContext/actionTypes.json
+++ b/agir/front/components/globalContext/actionTypes.json
@@ -8,8 +8,9 @@
   "SET_ALL_ACTIVITIES_AS_READ_ACTION": "setAllActivitiesAsRead",
 
   "DISMISS_REQUIRED_ACTION_ACTIVITY_ACTION": "dismissRequiredActionActivity",
+  "UNDO_REQUIRED_ACTION_ACTIVITY_DISMISSAL_ACTION": "undoRequiredActionActivityDismissal",
 
-  "SET_ANNOUNCEMENTS_AS_READ_ACTION": "setAllActivitiesAsRead",
+  "SET_ANNOUNCEMENTS_AS_READ_ACTION": "setAllAnnoucementsAsRead",
 
   "ADD_TOASTS": "addToasts",
   "CLEAR_TOAST": "clearToast",

--- a/agir/front/components/globalContext/actions.js
+++ b/agir/front/components/globalContext/actions.js
@@ -1,8 +1,9 @@
 import ACTION_TYPE from "./actionTypes";
 
 import {
-  dismissActivity,
-  setActivitiesAsRead,
+  setActivityAsInteracted,
+  setActivityAsDisplayed,
+  setActivitiesAsDisplayed,
 } from "@agir/activity/common/helpers";
 
 export const initFromScriptTag = () => {
@@ -48,7 +49,7 @@ export const setAllActivitiesAsRead = (ids = [], updateState = false) => async (
   dispatch
 ) => {
   try {
-    const success = await setActivitiesAsRead(ids);
+    const success = await setActivitiesAsDisplayed(ids);
     updateState &&
       success &&
       dispatch({
@@ -62,7 +63,7 @@ export const setAllActivitiesAsRead = (ids = [], updateState = false) => async (
 // REQUIRED ACTION ACTIVITIES
 export const dismissRequiredActionActivity = (id) => async (dispatch) => {
   try {
-    const success = await dismissActivity(id);
+    const success = await setActivityAsInteracted(id);
     success &&
       dispatch({
         type: ACTION_TYPE.DISMISS_REQUIRED_ACTION_ACTIVITY_ACTION,
@@ -73,10 +74,23 @@ export const dismissRequiredActionActivity = (id) => async (dispatch) => {
   }
 };
 
+export const undoRequiredActionActivityDismissal = (id) => async (dispatch) => {
+  try {
+    const success = await setActivityAsDisplayed(id);
+    success &&
+      dispatch({
+        type: ACTION_TYPE.UNDO_REQUIRED_ACTION_ACTIVITY_DISMISSAL_ACTION,
+        id,
+      });
+  } catch (e) {
+    console.log(e);
+  }
+};
+
 // ANNOUNCEMENTS
 export const setAnnouncementsAsRead = (ids = []) => async (dispatch) => {
   try {
-    const success = await setActivitiesAsRead(ids);
+    const success = await setActivitiesAsDisplayed(ids);
     success &&
       dispatch({
         type: ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION,

--- a/agir/front/components/globalContext/reducers.js
+++ b/agir/front/components/globalContext/reducers.js
@@ -1,11 +1,7 @@
 import shortUUID from "short-uuid";
 import ACTION_TYPE from "./actionTypes";
 
-import {
-  activityStatus,
-  getUnreadCount,
-  parseActivities,
-} from "@agir/activity/common/helpers";
+import { activityStatus, getUnreadCount } from "@agir/activity/common/helpers";
 
 // Reducers
 export const domain = (state = "https://actionpopulaire.fr", action) => {
@@ -52,8 +48,7 @@ export const activities = (state = [], action) => {
       if (!Array.isArray(action.activities)) {
         return state;
       }
-      const { unrequired } = parseActivities(action.activities);
-      return unrequired;
+      return action.activities;
     }
     case ACTION_TYPE.MARK_ACTIVITY_AS_READ_ACTION: {
       if (!action.id) {
@@ -83,11 +78,9 @@ export const activities = (state = [], action) => {
 export const requiredActionActivities = (state = [], action) => {
   if (
     action.type === ACTION_TYPE.SET_SESSION_CONTEXT_ACTION &&
-    Array.isArray(action.activities)
+    Array.isArray(action.requiredActionActivities)
   ) {
-    const { required } = parseActivities(action.activities);
-
-    return required;
+    return action.requiredActionActivities;
   }
   if (
     action.type === ACTION_TYPE.DISMISS_REQUIRED_ACTION_ACTIVITY_ACTION &&
@@ -98,6 +91,20 @@ export const requiredActionActivities = (state = [], action) => {
         ? {
             ...activity,
             status: activityStatus.STATUS_INTERACTED,
+          }
+        : activity
+    );
+  }
+  if (
+    action.type ===
+      ACTION_TYPE.UNDO_REQUIRED_ACTION_ACTIVITY_DISMISSAL_ACTION &&
+    action.id
+  ) {
+    return state.map((activity) =>
+      activity.id === action.id
+        ? {
+            ...activity,
+            status: activityStatus.STATUS_DISPLAYED,
           }
         : activity
     );

--- a/agir/front/components/globalContext/reducers.js
+++ b/agir/front/components/globalContext/reducers.js
@@ -93,7 +93,14 @@ export const requiredActionActivities = (state = [], action) => {
     action.type === ACTION_TYPE.DISMISS_REQUIRED_ACTION_ACTIVITY_ACTION &&
     action.id
   ) {
-    return state.filter((activity) => activity.id !== action.id);
+    return state.map((activity) =>
+      activity.id === action.id
+        ? {
+            ...activity,
+            status: activityStatus.STATUS_INTERACTED,
+          }
+        : activity
+    );
   }
   return state;
 };

--- a/agir/front/components/globalContext/reducers.js
+++ b/agir/front/components/globalContext/reducers.js
@@ -1,7 +1,11 @@
 import shortUUID from "short-uuid";
 import ACTION_TYPE from "./actionTypes";
 
-import { activityStatus, getUnreadCount } from "@agir/activity/common/helpers";
+import {
+  activityStatus,
+  getUnreadCount,
+  getUninteractedCount,
+} from "@agir/activity/common/helpers";
 
 // Reducers
 export const domain = (state = "https://actionpopulaire.fr", action) => {
@@ -172,7 +176,7 @@ export const getUnreadActivitiesCount = (state) =>
 export const getRequiredActionActivities = (state) =>
   state.requiredActionActivities;
 export const getRequiredActionActivityCount = (state) =>
-  state.requiredActionActivities ? state.requiredActionActivities.length : 0;
+  getUninteractedCount(state.requiredActionActivities);
 
 export const getUser = (state) => state.user;
 export const getIsConnected = (state) => !!state.user;

--- a/agir/front/components/globalContext/tests/actions.test.js
+++ b/agir/front/components/globalContext/tests/actions.test.js
@@ -109,53 +109,75 @@ describe("GlobalContext/actions", function () {
   });
   describe("setAllActivitiesAsRead action creator", function () {
     afterEach(() => {
-      activityHelpers.setActivitiesAsRead.mockClear();
+      activityHelpers.setActivitiesAsDisplayed.mockClear();
     });
-    it("should call activity helper function 'setActivitiesAsRead'", function () {
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+    it("should call activity helper function 'setActivitiesAsDisplayed'", function () {
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        0
+      );
       const ids = [1, 2, 3];
       dispatch(actions.setAllActivitiesAsRead(ids));
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
-      expect(activityHelpers.setActivitiesAsRead.mock.calls[0][0]).toEqual(ids);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        1
+      );
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls[0][0]).toEqual(
+        ids
+      );
     });
     it(`should not dispatch an action of type ${ACTION_TYPE.SET_ALL_ACTIVITIES_AS_READ_ACTION} if api calls rejects`, async function () {
-      activityHelpers.setActivitiesAsRead.mockResolvedValueOnce(false);
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+      activityHelpers.setActivitiesAsDisplayed.mockResolvedValueOnce(false);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        0
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
       const ids = [1, 2, 3];
       await dispatch(actions.setAllActivitiesAsRead(ids, true));
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        1
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
     });
     it(`should not dispatch an action of type ${ACTION_TYPE.SET_ALL_ACTIVITIES_AS_READ_ACTION} if api calls throws`, async function () {
       jest.spyOn(console, "log").mockReturnValueOnce();
-      activityHelpers.setActivitiesAsRead.mockRejectedValueOnce(
+      activityHelpers.setActivitiesAsDisplayed.mockRejectedValueOnce(
         new Error("Aïe!")
       );
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        0
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
       const ids = [1, 2, 3];
       await dispatch(actions.setAllActivitiesAsRead(ids, true));
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        1
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
       console.log.mockRestore();
     });
     it(`should not dispatch an action of type ${ACTION_TYPE.SET_ALL_ACTIVITIES_AS_READ_ACTION} if api calls succeeds but argument updateState is false`, async function () {
-      activityHelpers.setActivitiesAsRead.mockResolvedValueOnce(true);
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+      activityHelpers.setActivitiesAsDisplayed.mockResolvedValueOnce(true);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        0
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
       const ids = [1, 2, 3];
       await dispatch(actions.setAllActivitiesAsRead(ids, false));
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        1
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
     });
     it(`should dispatch an action of type ${ACTION_TYPE.SET_ALL_ACTIVITIES_AS_READ_ACTION} if api calls succeeds and argument updateState is true`, async function () {
-      activityHelpers.setActivitiesAsRead.mockResolvedValueOnce(true);
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+      activityHelpers.setActivitiesAsDisplayed.mockResolvedValueOnce(true);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        0
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
       const ids = [1, 2, 3];
       await dispatch(actions.setAllActivitiesAsRead(ids, true));
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        1
+      );
       expect(mockDispatch.mock.calls).toHaveLength(1);
       expect(mockDispatch.mock.calls[0][0]).toHaveProperty(
         "type",
@@ -165,42 +187,62 @@ describe("GlobalContext/actions", function () {
   });
   describe("dismissRequiredActionActivity action creator", function () {
     afterEach(() => {
-      activityHelpers.dismissActivity.mockClear();
+      activityHelpers.setActivityAsInteracted.mockClear();
     });
-    it("should call activity helper function 'dismissActivity'", function () {
-      expect(activityHelpers.dismissActivity.mock.calls).toHaveLength(0);
+    it("should call activity helper function 'setActivityAsInteracted'", function () {
+      expect(activityHelpers.setActivityAsInteracted.mock.calls).toHaveLength(
+        0
+      );
       const id = 10;
       dispatch(actions.dismissRequiredActionActivity(id));
-      expect(activityHelpers.dismissActivity.mock.calls).toHaveLength(1);
-      expect(activityHelpers.dismissActivity.mock.calls[0][0]).toEqual(id);
+      expect(activityHelpers.setActivityAsInteracted.mock.calls).toHaveLength(
+        1
+      );
+      expect(activityHelpers.setActivityAsInteracted.mock.calls[0][0]).toEqual(
+        id
+      );
     });
     it(`should not dispatch an action of type ${ACTION_TYPE.DISMISS_REQUIRED_ACTION_ACTIVITY_ACTION} if api calls rejects`, async function () {
-      activityHelpers.dismissActivity.mockResolvedValueOnce(false);
-      expect(activityHelpers.dismissActivity.mock.calls).toHaveLength(0);
+      activityHelpers.setActivityAsInteracted.mockResolvedValueOnce(false);
+      expect(activityHelpers.setActivityAsInteracted.mock.calls).toHaveLength(
+        0
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
       const id = 10;
       await dispatch(actions.dismissRequiredActionActivity(id));
-      expect(activityHelpers.dismissActivity.mock.calls).toHaveLength(1);
+      expect(activityHelpers.setActivityAsInteracted.mock.calls).toHaveLength(
+        1
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
     });
     it(`should not dispatch an action of type ${ACTION_TYPE.DISMISS_REQUIRED_ACTION_ACTIVITY_ACTION} if api calls throws`, async function () {
       jest.spyOn(console, "log").mockReturnValueOnce();
-      activityHelpers.dismissActivity.mockRejectedValueOnce(new Error("Aïe!"));
-      expect(activityHelpers.dismissActivity.mock.calls).toHaveLength(0);
+      activityHelpers.setActivityAsInteracted.mockRejectedValueOnce(
+        new Error("Aïe!")
+      );
+      expect(activityHelpers.setActivityAsInteracted.mock.calls).toHaveLength(
+        0
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
       const id = 10;
       await dispatch(actions.dismissRequiredActionActivity(id));
-      expect(activityHelpers.dismissActivity.mock.calls).toHaveLength(1);
+      expect(activityHelpers.setActivityAsInteracted.mock.calls).toHaveLength(
+        1
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
       console.log.mockRestore();
     });
     it(`should dispatch an action of type ${ACTION_TYPE.DISMISS_REQUIRED_ACTION_ACTIVITY_ACTION} if api calls succeeds`, async function () {
-      activityHelpers.dismissActivity.mockResolvedValueOnce(true);
-      expect(activityHelpers.dismissActivity.mock.calls).toHaveLength(0);
+      activityHelpers.setActivityAsInteracted.mockResolvedValueOnce(true);
+      expect(activityHelpers.setActivityAsInteracted.mock.calls).toHaveLength(
+        0
+      );
       expect(mockDispatch.mock.calls).toHaveLength(0);
       const id = 10;
       await dispatch(actions.dismissRequiredActionActivity(id));
-      expect(activityHelpers.dismissActivity.mock.calls).toHaveLength(1);
+      expect(activityHelpers.setActivityAsInteracted.mock.calls).toHaveLength(
+        1
+      );
       expect(mockDispatch.mock.calls).toHaveLength(1);
       expect(mockDispatch.mock.calls[0][0]).toHaveProperty(
         "type",
@@ -208,50 +250,117 @@ describe("GlobalContext/actions", function () {
       );
     });
   });
-  describe("setAnnouncementsAsRead action creator", function () {
+  describe("undoRequiredActionActivityDismissal action creator", function () {
     afterEach(() => {
-      activityHelpers.setActivitiesAsRead.mockClear();
+      activityHelpers.setActivityAsDisplayed.mockClear();
     });
-    it("should call activity helper function 'setActivitiesAsRead'", function () {
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
-      const ids = [1, 2, 3];
-      dispatch(actions.setAllActivitiesAsRead(ids));
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
-      expect(activityHelpers.setActivitiesAsRead.mock.calls[0][0]).toEqual(ids);
+    it("should call activity helper function 'setActivityAsDisplayed'", function () {
+      expect(activityHelpers.setActivityAsDisplayed.mock.calls).toHaveLength(0);
+      const id = 10;
+      dispatch(actions.undoRequiredActionActivityDismissal(id));
+      expect(activityHelpers.setActivityAsDisplayed.mock.calls).toHaveLength(1);
+      expect(activityHelpers.setActivityAsDisplayed.mock.calls[0][0]).toEqual(
+        id
+      );
     });
-    it(`should not dispatch an action of type ${ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION} if api calls rejects`, async function () {
-      activityHelpers.setActivitiesAsRead.mockResolvedValueOnce(false);
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+    it(`should not dispatch an action of type ${ACTION_TYPE.UNDO_REQUIRED_ACTION_ACTIVITY_DISMISSAL_ACTION} if api calls rejects`, async function () {
+      activityHelpers.setActivityAsDisplayed.mockResolvedValueOnce(false);
+      expect(activityHelpers.setActivityAsDisplayed.mock.calls).toHaveLength(0);
       expect(mockDispatch.mock.calls).toHaveLength(0);
-      const ids = [1, 2, 3];
-      await dispatch(actions.setAllActivitiesAsRead(ids, true));
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      const id = 10;
+      await dispatch(actions.undoRequiredActionActivityDismissal(id));
+      expect(activityHelpers.setActivityAsDisplayed.mock.calls).toHaveLength(1);
       expect(mockDispatch.mock.calls).toHaveLength(0);
     });
-    it(`should not dispatch an action of type ${ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION} if api calls throws`, async function () {
+    it(`should not dispatch an action of type ${ACTION_TYPE.UNDO_REQUIRED_ACTION_ACTIVITY_DISMISSAL_ACTION} if api calls throws`, async function () {
       jest.spyOn(console, "log").mockReturnValueOnce();
-      activityHelpers.setActivitiesAsRead.mockRejectedValueOnce(
+      activityHelpers.setActivityAsDisplayed.mockRejectedValueOnce(
         new Error("Aïe!")
       );
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+      expect(activityHelpers.setActivityAsDisplayed.mock.calls).toHaveLength(0);
       expect(mockDispatch.mock.calls).toHaveLength(0);
-      const ids = [1, 2, 3];
-      await dispatch(actions.setAllActivitiesAsRead(ids, true));
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      const id = 10;
+      await dispatch(actions.undoRequiredActionActivityDismissal(id));
+      expect(activityHelpers.setActivityAsDisplayed.mock.calls).toHaveLength(1);
       expect(mockDispatch.mock.calls).toHaveLength(0);
       console.log.mockRestore();
     });
-    it(`should dispatch an action of type ${ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION} if api calls succeeds`, async function () {
-      activityHelpers.setActivitiesAsRead.mockResolvedValueOnce(true);
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(0);
+    it(`should dispatch an action of type ${ACTION_TYPE.UNDO_REQUIRED_ACTION_ACTIVITY_DISMISSAL_ACTION} if api calls succeeds`, async function () {
+      activityHelpers.setActivityAsDisplayed.mockResolvedValueOnce(true);
+      expect(activityHelpers.setActivityAsDisplayed.mock.calls).toHaveLength(0);
       expect(mockDispatch.mock.calls).toHaveLength(0);
-      const ids = [1, 2, 3];
-      await dispatch(actions.setAllActivitiesAsRead(ids, true));
-      expect(activityHelpers.setActivitiesAsRead.mock.calls).toHaveLength(1);
+      const id = 10;
+      await dispatch(actions.undoRequiredActionActivityDismissal(id));
+      expect(activityHelpers.setActivityAsDisplayed.mock.calls).toHaveLength(1);
       expect(mockDispatch.mock.calls).toHaveLength(1);
       expect(mockDispatch.mock.calls[0][0]).toHaveProperty(
         "type",
-        ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION
+        ACTION_TYPE.UNDO_REQUIRED_ACTION_ACTIVITY_DISMISSAL_ACTION
+      );
+    });
+  });
+  describe("setAnnouncementsAsRead action creator", function () {
+    afterEach(() => {
+      activityHelpers.setActivitiesAsDisplayed.mockClear();
+    });
+    it("should call activity helper function 'setActivitiesAsDisplayed'", function () {
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        0
+      );
+      const ids = [1, 2, 3];
+      dispatch(actions.setAllActivitiesAsRead(ids));
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        1
+      );
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls[0][0]).toEqual(
+        ids
+      );
+    });
+    it(`should not dispatch an action of type ${ACTION_TYPE.SET_ANNOUNCEMENTS_AS_READ_ACTION} if api calls rejects`, async function () {
+      activityHelpers.setActivitiesAsDisplayed.mockResolvedValueOnce(false);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        0
+      );
+      expect(mockDispatch.mock.calls).toHaveLength(0);
+      const ids = [1, 2, 3];
+      await dispatch(actions.setAllActivitiesAsRead(ids, true));
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        1
+      );
+      expect(mockDispatch.mock.calls).toHaveLength(0);
+    });
+    it(`should not dispatch an action of type ${ACTION_TYPE.SET_ALL_ACTIVITIES_AS_READ_ACTION} if api calls throws`, async function () {
+      jest.spyOn(console, "log").mockReturnValueOnce();
+      activityHelpers.setActivitiesAsDisplayed.mockRejectedValueOnce(
+        new Error("Aïe!")
+      );
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        0
+      );
+      expect(mockDispatch.mock.calls).toHaveLength(0);
+      const ids = [1, 2, 3];
+      await dispatch(actions.setAllActivitiesAsRead(ids, true));
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        1
+      );
+      expect(mockDispatch.mock.calls).toHaveLength(0);
+      console.log.mockRestore();
+    });
+    it(`should dispatch an action of type ${ACTION_TYPE.SET_ALL_ACTIVITIES_AS_READ_ACTION} if api calls succeeds`, async function () {
+      activityHelpers.setActivitiesAsDisplayed.mockResolvedValueOnce(true);
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        0
+      );
+      expect(mockDispatch.mock.calls).toHaveLength(0);
+      const ids = [1, 2, 3];
+      await dispatch(actions.setAllActivitiesAsRead(ids, true));
+      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
+        1
+      );
+      expect(mockDispatch.mock.calls).toHaveLength(1);
+      expect(mockDispatch.mock.calls[0][0]).toHaveProperty(
+        "type",
+        ACTION_TYPE.SET_ALL_ACTIVITIES_AS_READ_ACTION
       );
     });
   });


### PR DESCRIPTION
- Split activity from required action activities backend-side on api/session endpoint serializer
- Do not hide dismissed required action activity, instead use a different style for interacted and non-interacted activities
- Allow undoing of required action activity dismissal