### PR TITLE
Gdp/group detail page

### DIFF
--- a/agir/front/components/allPages/TopBar.js
+++ b/agir/front/components/allPages/TopBar.js
@@ -8,6 +8,7 @@ import {
   getUser,
   getIsSessionLoaded,
   getBackLink,
+  getTopBarRightLink,
 } from "@agir/front/globalContext/reducers";
 
 import style from "@agir/front/genericComponents/_variables.scss";
@@ -152,20 +153,51 @@ const SearchBarInput = styled.input.attrs(() => ({ type: "text", name: "q" }))`
   }
 `;
 
-const ConnectionInfo = ({ user, routes }) =>
-  !user ? (
-    <>
-      <MenuLink href={routes.login} className="small-only">
-        <FeatherIcon name="user" />
-      </MenuLink>
-      <MenuLink href={routes.login} className="large-only">
-        <span>Connexion</span>
-      </MenuLink>
-      <MenuLink href={routes.join} className="large-only">
-        <span>Inscription</span>
-      </MenuLink>
-    </>
-  ) : (
+const TopBarRightLink = ({ user, routes, settingsLink }) => {
+  if (!user) {
+    return (
+      <>
+        <MenuLink href={routes.login} className="small-only">
+          <FeatherIcon name="user" />
+        </MenuLink>
+        <MenuLink href={routes.login} className="large-only">
+          <span>Connexion</span>
+        </MenuLink>
+        <MenuLink href={routes.join} className="large-only">
+          <span>Inscription</span>
+        </MenuLink>
+      </>
+    );
+  }
+  if (settingsLink) {
+    return (
+      <>
+        <MenuLink
+          to={settingsLink.to}
+          href={settingsLink.href}
+          route={settingsLink.route}
+          className="small-only"
+          title={settingsLink.label}
+          aria-label={settingsLink.label}
+        >
+          <FeatherIcon name="settings" />
+        </MenuLink>
+        <MenuLink
+          className="large-only"
+          href={
+            user.isInsoumise
+              ? routes.personalInformation
+              : routes.contactConfiguration
+          }
+        >
+          <FeatherIcon name="user" />
+          <span>{user.displayName}</span>
+        </MenuLink>
+      </>
+    );
+  }
+
+  return (
     <MenuLink
       href={
         user.isInsoumise
@@ -177,8 +209,8 @@ const ConnectionInfo = ({ user, routes }) =>
       <span className="large-only">{user.displayName}</span>
     </MenuLink>
   );
-
-ConnectionInfo.propTypes = {
+};
+TopBarRightLink.propTypes = {
   user: PropTypes.shape({
     displayName: PropTypes.string,
     isInsoumise: PropTypes.bool,
@@ -196,6 +228,12 @@ ConnectionInfo.propTypes = {
       ),
     ])
   ),
+  settingsLink: PropTypes.shape({
+    to: PropTypes.string,
+    href: PropTypes.string,
+    route: PropTypes.string,
+    label: PropTypes.string,
+  }),
 };
 
 export const PureTopBar = () => {
@@ -205,6 +243,7 @@ export const PureTopBar = () => {
   const user = useSelector(getUser);
   const isSessionLoaded = useSelector(getIsSessionLoaded);
   const backLink = useSelector(getBackLink);
+  const topBarRightLink = useSelector(getTopBarRightLink);
 
   return (
     <TopBarBar>
@@ -267,7 +306,11 @@ export const PureTopBar = () => {
               <FeatherIcon name="help-circle" />
               <span>Aide</span>
             </MenuLink>
-            <ConnectionInfo routes={routes} user={user} />
+            <TopBarRightLink
+              settingsLink={isSessionLoaded && topBarRightLink}
+              routes={routes}
+              user={user}
+            />
           </HorizontalFlex>
         </PageFadeIn>
       </TopBarContainer>

--- a/agir/front/components/app/Router.js
+++ b/agir/front/components/app/Router.js
@@ -7,7 +7,10 @@ import {
   useSelector,
 } from "@agir/front/globalContext/GlobalContext";
 import { getIsSessionLoaded } from "@agir/front/globalContext/reducers";
-import { setBackLink } from "@agir/front/globalContext/actions";
+import {
+  setBackLink,
+  setTopBarRightLink,
+} from "@agir/front/globalContext/actions";
 
 import Layout from "@agir/front/dashboardComponents/Layout";
 import ErrorBoundary from "./ErrorBoundary";
@@ -26,6 +29,7 @@ const Page = (props) => {
     dispatch(setBackLink(routeConfig.backLink));
     return () => {
       dispatch(setBackLink(null));
+      dispatch(setTopBarRightLink(null));
     };
   }, [isSessionLoaded, dispatch, routeConfig.backLink]);
 

--- a/agir/front/components/app/routes.config.js
+++ b/agir/front/components/app/routes.config.js
@@ -104,7 +104,7 @@ export const routeConfig = {
   }),
   groupDetails: new RouteConfig({
     id: "groupDetails",
-    pathname: "/groupes/:groupPk/",
+    pathname: "/groupes/:groupPk/:activeTab?",
     exact: true,
     label: "Details du groupe",
     Component: GroupPage,

--- a/agir/front/components/genericComponents/Tabs.js
+++ b/agir/front/components/genericComponents/Tabs.js
@@ -144,7 +144,6 @@ export const Tabs = (props) => {
 
   return (
     <>
-      {console.log(activeIndex)}
       <StyledMenu $stickyOffset={stickyOffset}>
         {tabs.map((tab, i) => (
           <button

--- a/agir/front/components/globalContext/actionTypes.json
+++ b/agir/front/components/globalContext/actionTypes.json
@@ -16,5 +16,6 @@
   "CLEAR_TOAST": "clearToast",
   "CLEAR_ALL_TOASTS": "clearAllToasts",
 
-  "SET_BACK_LINK_ACTION": "setBackLink"
+  "SET_BACK_LINK_ACTION": "setBackLink",
+  "SET_TOP_BAR_RIGHT_LINK_ACTION": "setTopBarRightLink"
 }

--- a/agir/front/components/globalContext/actions.js
+++ b/agir/front/components/globalContext/actions.js
@@ -126,4 +126,10 @@ export const setBackLink = (backLink) => ({
   backLink,
 });
 
+// TOP BAR RIGHT LINK
+export const setTopBarRightLink = (topBarRightLink) => ({
+  type: ACTION_TYPE.SET_TOP_BAR_RIGHT_LINK_ACTION,
+  topBarRightLink,
+});
+
 export default createDispatch;

--- a/agir/front/components/globalContext/reducers.js
+++ b/agir/front/components/globalContext/reducers.js
@@ -175,6 +175,16 @@ export const backLink = (state = null, action) => {
   return state;
 };
 
+export const topBarRightLink = (state = null, action) => {
+  if (action.type === ACTION_TYPE.INIT_ACTION) {
+    return action.topBarRightLink || state;
+  }
+  if (action.type === ACTION_TYPE.SET_TOP_BAR_RIGHT_LINK_ACTION) {
+    return action.topBarRightLink || null;
+  }
+  return state;
+};
+
 // Selectors
 export const getDomain = (state) => state.domain;
 
@@ -212,6 +222,13 @@ export const getBackLink = (state) => {
   return state.backLink;
 };
 
+export const getTopBarRightLink = (state) => {
+  if (!state.topBarRightLink) return null;
+  if (state.topBarRightLink.isProtected && state.isSessionLoaded && !state.user)
+    return null;
+  return state.topBarRightLink;
+};
+
 // Root reducer
 const reducers = {
   hasFeedbackButton,
@@ -226,6 +243,7 @@ const reducers = {
   routes,
   toasts,
   backLink,
+  topBarRightLink,
 };
 const rootReducer = (state, action) => {
   let newState = state;

--- a/agir/front/urls.py
+++ b/agir/front/urls.py
@@ -30,6 +30,21 @@ urlpatterns = [
     path(
         "groupes/<uuid:pk>/", views.SupportGroupDetailView.as_view(), name="view_group"
     ),
+    path(
+        "groupes/<uuid:pk>/agenda/",
+        views.SupportGroupDetailView.as_view(),
+        name="view_group_events",
+    ),
+    path(
+        "groupes/<uuid:pk>/comptes-rendus/",
+        views.SupportGroupDetailView.as_view(),
+        name="view_group_reports",
+    ),
+    path(
+        "groupes/<uuid:pk>/presentation/",
+        views.SupportGroupDetailView.as_view(),
+        name="view_group_info",
+    ),
     path("activite/", views.ActivityView.as_view(), name="list_activities",),
     path(
         "a-traiter/",

--- a/agir/groups/components/groupPage/GroupBanner.js
+++ b/agir/groups/components/groupPage/GroupBanner.js
@@ -1,8 +1,9 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components";
 
 import style from "@agir/front/genericComponents/_variables.scss";
+import { getGroupTypeWithLocation } from "./utils";
 
 import Map from "@agir/carte/common/Map";
 
@@ -71,18 +72,12 @@ const StyledBanner = styled.div`
 `;
 
 const GroupBanner = (props) => {
-  const { name, type, location, iconConfiguration } = props;
+  const { name, type, location, commune, iconConfiguration } = props;
 
-  const subtitle = React.useMemo(() => {
-    const { city, zip } = location || {};
-    if (!zip) {
-      return type;
-    }
-    if (!city) {
-      return `${type} (${zip})`;
-    }
-    return `${type} à ${city} (${zip})`;
-  }, [type, location]);
+  const subtitle = useMemo(
+    () => getGroupTypeWithLocation(type, location, commune),
+    [type, location, commune]
+  );
 
   return (
     <StyledBanner>
@@ -114,5 +109,8 @@ GroupBanner.propTypes = {
       coordinates: PropTypes.arrayOf(PropTypes.number),
     }),
   }).isRequired,
+  commune: PropTypes.shape({
+    nameOf: PropTypes.string,
+  }),
 };
 export default GroupBanner;

--- a/agir/groups/components/groupPage/GroupPage/GroupPage.js
+++ b/agir/groups/components/groupPage/GroupPage/GroupPage.js
@@ -29,5 +29,6 @@ export const GroupPage = (props) => {
 };
 GroupPage.propTypes = {
   isLoading: PropTypes.bool,
+  activeTab: PropTypes.string,
 };
 export default GroupPage;

--- a/agir/groups/components/groupPage/GroupPage/GroupPage.stories.js
+++ b/agir/groups/components/groupPage/GroupPage/GroupPage.stories.js
@@ -4,12 +4,21 @@ import group from "./group.json";
 import events from "./events.json";
 
 import { TestGlobalContextProvider } from "@agir/front/globalContext/GlobalContext";
+import GROUP_PAGE_TABS from "./tabs.config";
 
 import GroupPage from "./GroupPage";
 
 export default {
   component: GroupPage,
   title: "Group/GroupPage",
+  argTypes: {
+    activeTab: {
+      control: {
+        type: "select",
+        options: GROUP_PAGE_TABS.map((t) => t.slug),
+      },
+    },
+  },
 };
 
 const Template = (args) => (
@@ -29,6 +38,7 @@ Default.args = {
   ],
   upcomingEvents: events,
   pastEvents: events,
+  activeTab: GROUP_PAGE_TABS[0].slug,
 };
 export const Loading = Template.bind({});
 Loading.args = {

--- a/agir/groups/components/groupPage/GroupPage/GroupPage.stories.js
+++ b/agir/groups/components/groupPage/GroupPage/GroupPage.stories.js
@@ -45,6 +45,7 @@ export const WithPastReports = Template.bind({});
 WithPastReports.args = {
   ...Default.args,
   pastEventReports: events,
+  activeTab: "comptes-rendus",
 };
 export const NonMemberView = Template.bind({});
 NonMemberView.args = {

--- a/agir/groups/components/groupPage/GroupPage/MobileGroupPage.js
+++ b/agir/groups/components/groupPage/GroupPage/MobileGroupPage.js
@@ -4,6 +4,8 @@ import styled from "styled-components";
 
 import style from "@agir/front/genericComponents/_variables.scss";
 
+import { useTabs } from "./hooks";
+
 import { Column, Container, Row } from "@agir/front/genericComponents/grid";
 import Skeleton from "@agir/front/genericComponents/Skeleton";
 import Tabs from "@agir/front/genericComponents/Tabs";
@@ -30,29 +32,6 @@ export const MobileGroupPageSkeleton = () => (
     </Row>
   </Container>
 );
-
-const tabConfig = [
-  {
-    id: "info",
-    label: "Présentation",
-    isActive: true,
-  },
-  {
-    id: "agenda",
-    label: "Agenda",
-    isActive: ({ pastEvents, upcomingEvents }) => {
-      pastEvents = Array.isArray(pastEvents) ? pastEvents : [];
-      upcomingEvents = Array.isArray(upcomingEvents) ? upcomingEvents : [];
-      return pastEvents.length + upcomingEvents.length > 0;
-    },
-  },
-  {
-    id: "reports",
-    label: "Comptes-rendus",
-    isActive: ({ pastEventReports }) =>
-      Array.isArray(pastEventReports) && pastEventReports.length > 0,
-  },
-];
 
 const Tab = styled.div`
   max-width: 100%;
@@ -83,13 +62,7 @@ const MobileGroupPage = (props) => {
     pastEventReports,
   } = props;
 
-  const tabs = useMemo(
-    () =>
-      tabConfig.filter((tab) =>
-        typeof tab.isActive === "function" ? tab.isActive(props) : tab.isActive
-      ),
-    [props]
-  );
+  const tabProps = useTabs(props, true);
 
   if (!group) {
     return null;
@@ -104,37 +77,35 @@ const MobileGroupPage = (props) => {
     >
       <GroupBanner {...group} />
       <GroupUserActions {...group} />
-      <Tabs tabs={tabs}>
-        {({ handleNext }) => (
-          <Tab>
-            {Array.isArray(upcomingEvents) && upcomingEvents.length > 0 ? (
-              <Agenda>
-                <h3>Agenda</h3>
-                <GroupEventList
-                  events={[upcomingEvents[0]]}
-                  loadMore={handleNext}
-                  loadMoreLabel="Voir tout l'agenda"
-                />
-              </Agenda>
-            ) : null}
+      <Tabs {...tabProps} stickyOffset={72}>
+        <Tab>
+          {Array.isArray(upcomingEvents) && upcomingEvents.length > 0 ? (
+            <Agenda>
+              <h3>Agenda</h3>
+              <GroupEventList
+                events={[upcomingEvents[0]]}
+                loadMore={tabProps.onNextTab}
+                loadMoreLabel="Voir tout l'agenda"
+              />
+            </Agenda>
+          ) : null}
 
-            <GroupContactCard {...group} />
-            <GroupDescription {...group} />
-            <GroupLinks {...group} />
-            <GroupFacts {...group} />
-            <GroupLocation {...group} />
-            {group.routes && group.routes.donations && (
-              <GroupDonation url={group.routes.donations} />
-            )}
-            <ShareCard title="Partager le lien du groupe" />
+          <GroupContactCard {...group} />
+          <GroupDescription {...group} />
+          <GroupLinks {...group} />
+          <GroupFacts {...group} />
+          <GroupLocation {...group} />
+          {group.routes && group.routes.donations && (
+            <GroupDonation url={group.routes.donations} />
+          )}
+          <ShareCard title="Partager le lien du groupe" />
 
-            {Array.isArray(groupSuggestions) && groupSuggestions.length > 0 ? (
-              <div style={{ marginTop: 71, marginBottom: 71 }}>
-                <GroupSuggestions groups={groupSuggestions} />
-              </div>
-            ) : null}
-          </Tab>
-        )}
+          {Array.isArray(groupSuggestions) && groupSuggestions.length > 0 ? (
+            <div style={{ marginTop: 71, marginBottom: 71 }}>
+              <GroupSuggestions groups={groupSuggestions} />
+            </div>
+          ) : null}
+        </Tab>
         <Tab>
           <GroupEventList title="Événements à venir" events={upcomingEvents} />
           <GroupEventList
@@ -165,5 +136,6 @@ MobileGroupPage.propTypes = {
   isLoadingPastEvents: PropTypes.bool,
   loadMorePastEvents: PropTypes.func,
   pastEventReports: PropTypes.arrayOf(PropTypes.object),
+  tabs: PropTypes.arrayOf(PropTypes.object),
 };
 export default MobileGroupPage;

--- a/agir/groups/components/groupPage/GroupPage/hooks.js
+++ b/agir/groups/components/groupPage/GroupPage/hooks.js
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useMemo } from "react";
+import { useHistory } from "react-router-dom";
+import useSWR, { useSWRInfinite } from "swr";
+
+import logger from "@agir/lib/utils/logger";
+
+import GROUP_PAGE_TABS from "./tabs.config.js";
+
+const log = logger(__filename);
+
+export const useGroupDetail = (groupPk) => {
+  const { data: group } = useSWR(`/api/groupes/${groupPk}`);
+  log.debug("Group data", group);
+
+  const { data: groupSuggestions } = useSWR(
+    `/api/groupes/${groupPk}/suggestions`
+  );
+  log.debug("Group suggestions", groupSuggestions);
+
+  const { data: upcomingEvents } = useSWR(
+    `/api/groupes/${groupPk}/evenements/a-venir`
+  );
+  log.debug("Group upcoming events", upcomingEvents);
+
+  const { data: pastEventData, size, setSize, isValidating } = useSWRInfinite(
+    (pageIndex) =>
+      `/api/groupes/${groupPk}/evenements/passes?page=${
+        pageIndex + 1
+      }&page_size=3`
+  );
+  const pastEvents = useMemo(() => {
+    let events = [];
+    if (!Array.isArray(pastEventData)) {
+      return events;
+    }
+    pastEventData.forEach(({ results }) => {
+      if (Array.isArray(results)) {
+        events = events.concat(results);
+      }
+    });
+    return events;
+  }, [pastEventData]);
+  log.debug("Group past events", pastEvents);
+  const pastEventCount = useMemo(() => {
+    if (!Array.isArray(pastEventData) || !pastEventData[0]) {
+      return 0;
+    }
+    return pastEventData[0].count;
+  }, [pastEventData]);
+  const loadMorePastEvents = useCallback(() => {
+    setSize(size + 1);
+  }, [setSize, size]);
+  const isLoadingPastEvents = !pastEventData || isValidating;
+
+  const { data: pastEventReports } = useSWR(
+    `/api/groupes/${groupPk}/evenements/compte-rendus`
+  );
+  log.debug("Group past event reports", pastEventReports);
+
+  return {
+    group,
+    groupSuggestions,
+    upcomingEvents,
+    pastEvents,
+    pastEventCount,
+    loadMorePastEvents:
+      pastEventCount > pastEvents.length ? loadMorePastEvents : undefined,
+    isLoadingPastEvents,
+    pastEventReports,
+  };
+};
+
+export const useTabs = (props, isMobile = true) => {
+  const { activeTab } = props;
+  const history = useHistory();
+
+  const tabs = useMemo(
+    () =>
+      GROUP_PAGE_TABS.filter((tab) =>
+        typeof tab.isActive === "function"
+          ? tab.isActive(props, isMobile)
+          : tab.isActive
+      ).map((tab) => ({
+        ...tab,
+        to: `/groupes/${props.group.id}/${tab.slug}/`,
+        goToTab: () => {
+          history.push(`/groupes/${props.group.id}/${tab.slug}/`);
+        },
+      })),
+    [history, props, isMobile]
+  );
+
+  const { active, activeIndex } = useMemo(() => {
+    const result = { active: tabs[0], activeIndex: 0 };
+    tabs.forEach((tab, i) => {
+      if (tab.slug === activeTab) {
+        result.active = tab;
+        result.activeIndex = i;
+      }
+    });
+    return result;
+  }, [tabs, activeTab]);
+
+  const handleTabChange = useCallback((tab) => {
+    tab.goToTab();
+  }, []);
+
+  const handleNextTab = useCallback(() => {
+    const nextIndex = Math.min(activeIndex + 1, tabs.length - 1);
+    tabs[nextIndex].goToTab();
+  }, [activeIndex, tabs]);
+
+  const handlePrevTab = useCallback(() => {
+    const prevIndex = Math.max(0, activeIndex - 1);
+    tabs[prevIndex].goToTab();
+  }, [activeIndex, tabs]);
+
+  useEffect(() => {
+    activeTab !== active.id && history.push(active.to);
+  }, [history, activeTab, active.id, active.to]);
+
+  return {
+    tabs: tabs.map((tab) => ({
+      ...tab,
+      isActive: active.id === tab.id || undefined,
+    })),
+    onTabChange: handleTabChange,
+    onNextTab: handleNextTab,
+    onPrevTab: handlePrevTab,
+    activeTab: active,
+    activeTabIndex: activeIndex,
+  };
+};

--- a/agir/groups/components/groupPage/GroupPage/index.js
+++ b/agir/groups/components/groupPage/GroupPage/index.js
@@ -1,9 +1,7 @@
 import PropTypes from "prop-types";
-import React, { useCallback, useMemo } from "react";
-import useSWR, { useSWRInfinite } from "swr";
-import GroupPageComponent from "./GroupPage";
+import React, { useEffect } from "react";
 
-import logger from "@agir/lib/utils/logger";
+import GroupPageComponent from "./GroupPage";
 
 import {
   useDispatch,
@@ -16,62 +14,29 @@ import {
   getBackLink,
 } from "@agir/front/globalContext/reducers";
 
-const log = logger(__filename);
+import { useGroupDetail } from "./hooks";
 
 const GroupPage = (props) => {
-  const { groupPk } = props;
-  const { data: group } = useSWR(`/api/groupes/${groupPk}`);
-  log.debug("Group data", group);
-  const { data: groupSuggestions } = useSWR(
-    `/api/groupes/${groupPk}/suggestions`
-  );
-  log.debug("Group suggestions", groupSuggestions);
-  const { data: upcomingEvents } = useSWR(
-    `/api/groupes/${groupPk}/evenements/a-venir`
-  );
-  log.debug("Group upcoming events", upcomingEvents);
-  const { data: pastEventData, size, setSize, isValidating } = useSWRInfinite(
-    (pageIndex) =>
-      `/api/groupes/${groupPk}/evenements/passes?page=${
-        pageIndex + 1
-      }&page_size=3`
-  );
-  const pastEvents = useMemo(() => {
-    let events = [];
-    if (!Array.isArray(pastEventData)) {
-      return events;
-    }
-    pastEventData.forEach(({ results }) => {
-      if (Array.isArray(results)) {
-        events = events.concat(results);
-      }
-    });
-    return events;
-  }, [pastEventData]);
-  log.debug("Group past events", pastEvents);
-  const pastEventCount = useMemo(() => {
-    if (!Array.isArray(pastEventData) || !pastEventData[0]) {
-      return 0;
-    }
-    return pastEventData[0].count;
-  }, [pastEventData]);
-  const loadMorePastEvents = useCallback(() => {
-    setSize(size + 1);
-  }, [setSize, size]);
-  const isLoadingPastEvents = !pastEventData || isValidating;
-  const { data: pastEventReports } = useSWR(
-    `/api/groupes/${groupPk}/evenements/compte-rendus`
-  );
-  log.debug("Group past event reports", pastEventReports);
+  const { groupPk, activeTab } = props;
 
   const isSessionLoaded = useSelector(getIsSessionLoaded);
   const isConnected = useSelector(getIsConnected);
   const backLink = useSelector(getBackLink);
   const dispatch = useDispatch();
 
+  const {
+    group,
+    groupSuggestions,
+    upcomingEvents,
+    pastEvents,
+    loadMorePastEvents,
+    isLoadingPastEvents,
+    pastEventReports,
+  } = useGroupDetail(groupPk);
+
   const { is2022 } = group || {};
 
-  React.useEffect(() => {
+  useEffect(() => {
     is2022 === true && dispatch(setIs2022());
   }, [is2022, dispatch]);
 
@@ -84,15 +49,15 @@ const GroupPage = (props) => {
       upcomingEvents={upcomingEvents}
       pastEvents={pastEvents}
       isLoadingPastEvents={isLoadingPastEvents}
-      loadMorePastEvents={
-        pastEventCount > pastEvents.length ? loadMorePastEvents : undefined
-      }
+      loadMorePastEvents={loadMorePastEvents}
       pastEventReports={pastEventReports}
       groupSuggestions={Array.isArray(groupSuggestions) ? groupSuggestions : []}
+      activeTab={activeTab}
     />
   );
 };
 GroupPage.propTypes = {
   groupPk: PropTypes.string,
+  activeTab: PropTypes.string,
 };
 export default GroupPage;

--- a/agir/groups/components/groupPage/GroupPage/index.js
+++ b/agir/groups/components/groupPage/GroupPage/index.js
@@ -7,7 +7,10 @@ import {
   useDispatch,
   useSelector,
 } from "@agir/front/globalContext/GlobalContext";
-import { setIs2022 } from "@agir/front/globalContext/actions";
+import {
+  setIs2022,
+  setTopBarRightLink,
+} from "@agir/front/globalContext/actions";
 import {
   getIsSessionLoaded,
   getIsConnected,
@@ -34,11 +37,22 @@ const GroupPage = (props) => {
     pastEventReports,
   } = useGroupDetail(groupPk);
 
-  const { is2022 } = group || {};
+  const { is2022, isManager, routes } = group || {};
 
   useEffect(() => {
     is2022 === true && dispatch(setIs2022());
   }, [is2022, dispatch]);
+
+  useEffect(() => {
+    isManager &&
+      routes.settings &&
+      dispatch(
+        setTopBarRightLink({
+          href: routes.settings,
+          label: "Gestion du groupe",
+        })
+      );
+  }, [isManager, routes, dispatch]);
 
   return (
     <GroupPageComponent

--- a/agir/groups/components/groupPage/GroupPage/tabs.config.js
+++ b/agir/groups/components/groupPage/GroupPage/tabs.config.js
@@ -1,0 +1,30 @@
+const tabs = [
+  {
+    id: "info",
+    slug: "presentation",
+    label: "Présentation",
+    isActive: (_, isMobile) => !!isMobile,
+  },
+  {
+    id: "agenda",
+    slug: "agenda",
+    label: "Agenda",
+    isActive: ({ pastEvents, upcomingEvents }, isMobile) => {
+      if (!isMobile) {
+        return true;
+      }
+      pastEvents = Array.isArray(pastEvents) ? pastEvents : [];
+      upcomingEvents = Array.isArray(upcomingEvents) ? upcomingEvents : [];
+      return pastEvents.length + upcomingEvents.length > 0;
+    },
+  },
+  {
+    id: "reports",
+    slug: "comptes-rendus",
+    label: "Comptes-rendus",
+    isActive: ({ pastEventReports }) =>
+      Array.isArray(pastEventReports) && pastEventReports.length > 0,
+  },
+];
+
+export default tabs;

--- a/agir/groups/components/groupPage/GroupUserActions.js
+++ b/agir/groups/components/groupPage/GroupUserActions.js
@@ -145,7 +145,7 @@ const GroupLinks = (props) => {
                   inline
                   small
                   name="settings"
-                  color={style.primary}
+                  color={style.primary500}
                 />
                 <a href={routes.admin}>Administration</a>
               </li>

--- a/agir/groups/components/groupPage/utils.js
+++ b/agir/groups/components/groupPage/utils.js
@@ -1,0 +1,29 @@
+const ARTICLES = {
+  "de ": "à ",
+  "d'": "à ",
+  "du ": "au ",
+  "de la ": "à la ",
+  "des ": "aux ",
+  "de l'": "à l'",
+  "de las ": "à las ",
+  "de los ": "à los ",
+};
+
+export const getGroupTypeWithLocation = (type, location, commune) => {
+  const { city, zip } = location || {};
+  const { nameOf } = commune || {};
+  if (!zip) {
+    return type;
+  }
+  if (!city && !nameOf) {
+    return `${type} (${zip})`;
+  }
+  if (!nameOf) {
+    return `${type} à ${city} (${zip})`;
+  }
+  const city_part = Object.entries(ARTICLES).reduce(
+    (string, [key, value]) => string.replace(new RegExp("^" + key, "i"), value),
+    nameOf
+  );
+  return `${type} ${city_part} (${zip})`;
+};

--- a/agir/groups/components/groupPage/utils.test.js
+++ b/agir/groups/components/groupPage/utils.test.js
@@ -1,0 +1,86 @@
+import { getGroupTypeWithLocation } from "./utils";
+
+describe("agir.groups.groupPage.utils", function () {
+  describe("getGroupTypeWithLocation", function () {
+    it("should return arg type if location.zip is falsy", function () {
+      const groupType = "Groupe local";
+      let result = getGroupTypeWithLocation(groupType, null);
+      expect(result).toEqual(groupType);
+      result = getGroupTypeWithLocation(groupType, { zip: null });
+      expect(result).toEqual(groupType);
+    });
+    it("should return arg type and zip if location.city and commune.nameOf are falsy", function () {
+      const groupType = "Groupe local";
+      const location = { zip: "75019" };
+      const expected = `${groupType} (${location.zip})`;
+      const result = getGroupTypeWithLocation(groupType, location);
+      expect(result).toEqual(expected);
+    });
+    it("should return arg type, zip and city if commune.nameOf is falsy", function () {
+      const groupType = "Groupe local";
+      const location = { zip: "75019", city: "Paris" };
+      const expected = `${groupType} à ${location.city} (${location.zip})`;
+      let result = getGroupTypeWithLocation(groupType, location, null);
+      expect(result).toEqual(expected);
+      result = getGroupTypeWithLocation(groupType, location, { nameOf: null });
+    });
+    it("should return arg type, zip and modified nameOf if commune.nameOf is truthy", function () {
+      let expected = "XXXXX à Bois-d'Arcy (XXXXX)";
+      let result = getGroupTypeWithLocation(
+        "XXXXX",
+        { zip: "XXXXX" },
+        { nameOf: "de Bois-d'Arcy" }
+      );
+      expect(result).toEqual(expected);
+      expected = "XXXXX à Aubervilliers (XXXXX)";
+      result = getGroupTypeWithLocation(
+        "XXXXX",
+        { zip: "XXXXX" },
+        { nameOf: "d'Aubervilliers" }
+      );
+      expect(result).toEqual(expected);
+      expected = "XXXXX au Havre (XXXXX)";
+      result = getGroupTypeWithLocation(
+        "XXXXX",
+        { zip: "XXXXX" },
+        { nameOf: "du Havre" }
+      );
+      expect(result).toEqual(expected);
+      expected = "XXXXX à la Loupe (XXXXX)";
+      result = getGroupTypeWithLocation(
+        "XXXXX",
+        { zip: "XXXXX" },
+        { nameOf: "de la Loupe" }
+      );
+      expect(result).toEqual(expected);
+      expected = "XXXXX aux Lilas (XXXXX)";
+      result = getGroupTypeWithLocation(
+        "XXXXX",
+        { zip: "XXXXX" },
+        { nameOf: "des Lilas" }
+      );
+      expect(result).toEqual(expected);
+      expected = "XXXXX à l'Arbresle (XXXXX)";
+      result = getGroupTypeWithLocation(
+        "XXXXX",
+        { zip: "XXXXX" },
+        { nameOf: "de l'Arbresle" }
+      );
+      expect(result).toEqual(expected);
+      expected = "XXXXX à las Vegas (XXXXX)";
+      result = getGroupTypeWithLocation(
+        "XXXXX",
+        { zip: "XXXXX" },
+        { nameOf: "de las Vegas" }
+      );
+      expect(result).toEqual(expected);
+      expected = "XXXXX à los Angeles (XXXXX)";
+      result = getGroupTypeWithLocation(
+        "XXXXX",
+        { zip: "XXXXX" },
+        { nameOf: "de los Angeles" }
+      );
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/agir/groups/serializers.py
+++ b/agir/groups/serializers.py
@@ -6,6 +6,7 @@ from . import models
 from .actions import get_promo_codes
 from .models import Membership
 from ..front.serializer_utils import RoutesField
+from agir.lib.geo import get_commune
 from agir.lib.serializers import (
     FlexibleFieldsMixin,
     LocationSerializer,
@@ -153,6 +154,7 @@ class SupportGroupDetailSerializer(FlexibleFieldsMixin, serializers.Serializer):
 
     routes = serializers.SerializerMethodField()
     discountCodes = serializers.SerializerMethodField()
+    commune = serializers.SerializerMethodField()
 
     def to_representation(self, instance):
         user = self.context["request"].user
@@ -272,3 +274,12 @@ class SupportGroupDetailSerializer(FlexibleFieldsMixin, serializers.Serializer):
                 for code, date in get_promo_codes(obj)
             ]
         return []
+
+    def get_commune(self, obj):
+        commune = get_commune(obj)
+        if commune is not None:
+            commune = {
+                "name": commune.nom_complet,
+                "nameOf": commune.nom_avec_charniere,
+            }
+        return commune

--- a/agir/groups/views/api_views.py
+++ b/agir/groups/views/api_views.py
@@ -89,6 +89,9 @@ class NearGroupsAPIView(ListAPIView):
         )
 
     def get_queryset(self):
+        if self.supportgroup.coordinates is None:
+            return SupportGroup.objects.none()
+
         groups = (
             SupportGroup.objects.active()
             .exclude(pk=self.supportgroup.pk)
@@ -100,9 +103,9 @@ class NearGroupsAPIView(ListAPIView):
 
         groups = groups.annotate(
             distance=Distance("coordinates", self.supportgroup.coordinates)
-        ).order_by("distance")[:3]
+        ).order_by("distance")
 
-        return groups
+        return groups[:3]
 
     def dispatch(self, request, pk, *args, **kwargs):
         self.person = request.user.person

--- a/agir/lib/tests/test_geo.py
+++ b/agir/lib/tests/test_geo.py
@@ -8,7 +8,7 @@ from functools import wraps
 
 from django.test import TestCase
 
-from agir.lib.geo import geocode_france
+from agir.lib.geo import geocode_france, get_commune
 from agir.lib.models import LocationMixin
 from agir.people.models import Person
 
@@ -175,3 +175,50 @@ class FranceGeocodingTestCase(TestCase):
         self.assertIsNotNone(self.person.coordinates)
         self.assertEqual(self.person.coordinates_type, LocationMixin.COORDINATES_CITY)
         self.assertEqual(self.person.location_city, "Belan-sur-Ource")
+
+    @with_no_request
+    def test_get_commune_with_citycode(self):
+        self.person.location_citycode = "21058"
+        self.person.save()
+        commune = get_commune(self.person)
+        self.assertIsNotNone(commune)
+        self.assertEqual(commune.nom, "Belan-sur-Ource")
+
+    @with_no_request
+    def test_get_commune_with_citycode(self):
+        self.person.location_citycode = "21058"
+        self.person.location_city = ""
+        self.person.location_zip = ""
+        self.person.save()
+        commune = get_commune(self.person)
+        self.assertIsNotNone(commune)
+        self.assertEqual(commune.nom, "Belan-sur-Ource")
+
+    @with_no_request
+    def test_get_commune_with_zip(self):
+        self.person.location_citycode = ""
+        self.person.location_city = ""
+        self.person.location_zip = "21000"
+        self.person.save()
+        commune = get_commune(self.person)
+        self.assertIsNotNone(commune)
+        self.assertEqual(commune.nom, "Dijon")
+
+    @with_no_request
+    def test_get_commune_with_city(self):
+        self.person.location_citycode = ""
+        self.person.location_city = "belan sur ource"
+        self.person.location_zip = ""
+        self.person.save()
+        commune = get_commune(self.person)
+        self.assertIsNotNone(commune)
+        self.assertEqual(commune.nom, "Belan-sur-Ource")
+
+    @with_no_request
+    def test_get_commune_with_no_location(self):
+        self.person.location_citycode = ""
+        self.person.location_city = ""
+        self.person.location_zip = ""
+        self.person.save()
+        commune = get_commune(self.person)
+        self.assertIsNone(commune)


### PR DESCRIPTION
- Add commune to group detail serializer to account for the group city name article inside sentences that use it
- Link group detail page to frontend router and refactor the Mobile and Desktop tab systems
- Add topBarRightLink to global context (to allow individual pages to override the default)