### PR TITLE
Add fallback for individual first name to "new-attendee" activity

### DIFF
--- a/agir/activity/components/page__activities/ActivityCard.js
+++ b/agir/activity/components/page__activities/ActivityCard.js
@@ -1,18 +1,19 @@
-import Card from "@agir/front/genericComponents/Card";
-import React, { useMemo } from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components";
 import { Interval } from "luxon";
+import PropTypes from "prop-types";
+import React, { useMemo } from "react";
+import styled from "styled-components";
 
-import { routeConfig } from "@agir/front/app/routes.config";
-import Link from "@agir/front/app/Link";
-
-import EventCard from "@agir/front/genericComponents/EventCard";
-import { Column, Row } from "@agir/front/genericComponents/grid";
-import style from "@agir/front/genericComponents/_variables.scss";
-import FeatherIcon from "@agir/front/genericComponents/FeatherIcon";
-import { dateFromISOString, displayHumanDate } from "@agir/lib/utils/time";
 import { activityStatus } from "@agir/activity/common/helpers";
+import { dateFromISOString, displayHumanDate } from "@agir/lib/utils/time";
+import { getGenderedWord } from "@agir/lib/utils/display";
+import { routeConfig } from "@agir/front/app/routes.config";
+import style from "@agir/front/genericComponents/_variables.scss";
+
+import Card from "@agir/front/genericComponents/Card";
+import { Column, Row } from "@agir/front/genericComponents/grid";
+import EventCard from "@agir/front/genericComponents/EventCard";
+import FeatherIcon from "@agir/front/genericComponents/FeatherIcon";
+import Link from "@agir/front/app/Link";
 
 import CONFIG from "./activity.config.json";
 
@@ -275,7 +276,12 @@ const ActivityCard = (props) => {
     case "new-attendee":
       return (
         <ActivityCardContainer {...props}>
-          {Individual || "Quelqu'un"} s'est inscrit à votre événement {Event}
+          <strong>
+            {(individual && (individual.firstName || individual.email)) ||
+              "Quelqu'un"}
+          </strong>{" "}
+          s'est {getGenderedWord(individual && individual.gender, "inscrit·e")}{" "}
+          à votre événement {Event}
         </ActivityCardContainer>
       );
     case "event-update":

--- a/agir/activity/components/page__activities/ActivityCard.stories.js
+++ b/agir/activity/components/page__activities/ActivityCard.stories.js
@@ -48,7 +48,6 @@ const Template = decorateArgs(
   convertDatetimes,
   reorganize(
     {
-      individual: { firstName: "individual" },
       "event.location": {
         name: "event.locationName",
         address: "event.locationAddress",
@@ -72,7 +71,10 @@ Default.args = {
       manage: "#group-manage",
     },
   },
-  individual: "Clara Zetkin",
+  individual: {
+    firstName: "Clara",
+    email: "clara@example.com",
+  },
   timestamp: DateTime.local().minus({ hours: 5 }).toISO(),
   meta: {
     totalReferrals: 10,

--- a/agir/activity/serializers.py
+++ b/agir/activity/serializers.py
@@ -32,7 +32,9 @@ class ActivitySerializer(FlexibleFieldsMixin, serializers.ModelSerializer):
     supportGroup = SupportGroupSerializer(
         source="supportgroup", fields=["name", "url", "routes"], read_only=True
     )
-    individual = PersonSerializer(fields=["firstName", "email"], read_only=True)
+    individual = PersonSerializer(
+        fields=["firstName", "email", "gender"], read_only=True
+    )
 
     status = serializers.CharField()
 

--- a/agir/lib/components/utils/display.js
+++ b/agir/lib/components/utils/display.js
@@ -31,3 +31,59 @@ export function displayPrice(n, forceCents = false) {
 
   return displayNumber(n / 100, 2) + NBSP + "€";
 }
+
+export const GENDER = {
+  female: "F",
+  male: "M",
+  other: "O",
+};
+/**
+ * function getGenderedWord
+ *
+ *
+ */
+export const getGenderedWord = (
+  gender,
+  inclusiveWord,
+  feminineWord,
+  masculineWord
+) => {
+  if (typeof inclusiveWord !== "string") {
+    return "";
+  }
+  inclusiveWord = inclusiveWord.trim();
+  gender = typeof gender === "string" ? gender.toUpperCase() : null;
+  if (
+    !gender ||
+    !Object.values(GENDER).includes(gender) ||
+    gender === GENDER.other
+  ) {
+    return inclusiveWord;
+  }
+  if (gender === GENDER.female && feminineWord) {
+    return feminineWord;
+  }
+  if (gender == GENDER.male && masculineWord) {
+    return masculineWord;
+  }
+  // Automatic gendering of inclusive word only works for words whose suffix is either "e" or "es"
+  const parsedWord = inclusiveWord.match(/^(.+)[⋅|·]{1}(e{1}s?)$/i);
+  if (!Array.isArray(parsedWord)) {
+    return inclusiveWord;
+  }
+  let [, root, suffix] = parsedWord;
+  const commonPlural =
+    suffix.split("").pop().toLowerCase() === "s" &&
+    root.split("").pop().toLowerCase() !== "s" &&
+    root.split("").pop().toLowerCase() !== "x"
+      ? suffix.split("").pop()
+      : "";
+  suffix = commonPlural ? suffix.slice(0, -1) : suffix;
+  const commonRootLength = commonPlural
+    ? root.length - suffix.length + 1
+    : root.length;
+
+  return gender === GENDER.female
+    ? `${root.slice(0, commonRootLength)}${suffix}${commonPlural}`
+    : `${root}${commonPlural}`;
+};

--- a/agir/lib/components/utils/display.test.js
+++ b/agir/lib/components/utils/display.test.js
@@ -1,0 +1,80 @@
+import { GENDER, getGenderedWord } from "./display";
+
+describe("agir.lib.utils.display", function () {
+  describe("getGenderedWord function", function () {
+    const testCases = [
+      {
+        args: [],
+        expected: "",
+      },
+      {
+        args: [GENDER.other, 12345],
+        expected: "",
+      },
+      {
+        args: [null, "Insoumis·e"],
+        expected: "Insoumis·e",
+      },
+      {
+        args: ["not" + GENDER.female, "Insoumis·e"],
+        expected: "Insoumis·e",
+      },
+      {
+        args: [GENDER.other, "Insoumis·e"],
+        expected: "Insoumis·e",
+      },
+      {
+        args: [GENDER.female, "Insoumis·e", "Insoumise", "Insoumis"],
+        expected: "Insoumise",
+      },
+      {
+        args: [GENDER.male, "Insoumis·e", "Insoumise", "Insoumis"],
+        expected: "Insoumis",
+      },
+      {
+        args: [GENDER.other, "Insoumis·e", "Insoumise", "Insoumis"],
+        expected: "Insoumis·e",
+      },
+      {
+        args: [GENDER.female, "Insoumis·e"],
+        expected: "Insoumise",
+      },
+      {
+        args: [GENDER.male, "Insoumis⋅e"],
+        expected: "Insoumis",
+      },
+      {
+        args: [GENDER.female, "Insoumis·es"],
+        expected: "Insoumises",
+      },
+      {
+        args: [GENDER.male, "Insoumis·es"],
+        expected: "Insoumis",
+      },
+      {
+        args: [GENDER.female, "ÉLU·ES"],
+        expected: "ÉLUES",
+      },
+      {
+        args: [GENDER.male, "ÉLU·ES"],
+        expected: "ÉLUS",
+      },
+      {
+        args: [GENDER.female, "heureux·ses"],
+        expected: "heureux·ses",
+      },
+      {
+        args: [GENDER.male, "heureux·ses"],
+        expected: "heureux·ses",
+      },
+    ];
+    testCases.forEach(({ args, expected }) => {
+      it(`It should return "${expected}" with arguments (${args.join(
+        ","
+      )})`, function () {
+        const result = getGenderedWord(...args);
+        expect(result).toEqual(expected);
+      });
+    });
+  });
+});

--- a/agir/people/serializers.py
+++ b/agir/people/serializers.py
@@ -296,5 +296,7 @@ class PersonSerializer(FlexibleFieldsMixin, serializers.Serializer):
 
     newsletters = serializers.ListField()
 
+    gender = serializers.CharField()
+
     def get_fullName(self, obj: Person):
         return obj.get_full_name()


### PR DESCRIPTION
- Use individual email instead of his/her first name if not defined
- Add a getGenderedWord utility function
- Add gender field to activity serializer individual property