### PR TITLE
feat: comment out participationCount from event serializer

### DIFF
--- a/agir/activity/serializers.py
+++ b/agir/activity/serializers.py
@@ -20,7 +20,7 @@ class ActivitySerializer(FlexibleFieldsMixin, serializers.ModelSerializer):
             "name",
             "startTime",
             "endTime",
-            "participantCount",
+            # "participantCount",
             "illustration",
             "schedule",
             "location",

--- a/agir/events/components/eventPage/EventInfoCard.js
+++ b/agir/events/components/eventPage/EventInfoCard.js
@@ -40,7 +40,7 @@ EventInfoCard.propTypes = {
   groups: PropTypes.arrayOf(
     PropTypes.shape({ name: PropTypes.string, url: PropTypes.string })
   ),
-  participantCount: PropTypes.number.isRequired,
+  participantCount: PropTypes.number,
   is2022: PropTypes.bool,
 };
 

--- a/agir/events/serializers.py
+++ b/agir/events/serializers.py
@@ -65,7 +65,7 @@ class EventSerializer(FlexibleFieldsMixin, serializers.Serializer):
 
     isOrganizer = serializers.SerializerMethodField()
     rsvp = serializers.SerializerMethodField()
-    participantCount = serializers.IntegerField(source="participants")
+    # participantCount = serializers.IntegerField(source="participants")
 
     options = EventOptionsSerializer(source="*")
 

--- a/agir/events/views/api_views.py
+++ b/agir/events/views/api_views.py
@@ -28,7 +28,7 @@ class EventRsvpedAPIView(ListAPIView):
             fields=[
                 "id",
                 "name",
-                "participantCount",
+                # "participantCount",
                 "illustration",
                 "hasSubscriptionForm",
                 "startTime",
@@ -83,7 +83,7 @@ class EventSuggestionsAPIView(ListAPIView):
             fields=[
                 "id",
                 "name",
-                "participantCount",
+                # "participantCount",
                 "illustration",
                 "hasSubscriptionForm",
                 "startTime",

--- a/agir/front/components/genericComponents/EventCard.js
+++ b/agir/front/components/genericComponents/EventCard.js
@@ -216,7 +216,7 @@ const EventCard = (props) => {
 EventCard.propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  participantCount: PropTypes.number.isRequired,
+  participantCount: PropTypes.number,
   hasSubscriptionForm: PropTypes.bool,
   illustration: PropTypes.string,
   schedule: PropTypes.instanceOf(Interval).isRequired,


### PR DESCRIPTION
Cacher temporairement le nombre des participants à un événement, en attendant de pouvoir parametrer son affichage à la création de l'événement.