### PR TITLE
fix: useCopyToClipboard hook clipboard fallback

### DIFF
--- a/agir/activity/components/page__requiredActivities/RequiredActivityList.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActivityList.js
@@ -76,8 +76,6 @@ const RequiredActivityList = () => {
 
   const tabs = useMemo(() => ["non traité", "voir tout"], []);
 
-  visibleActivities.forEach((a) => console.log(a.id, a.type, a.status));
-
   return (
     <>
       <Helmet>

--- a/agir/front/components/genericComponents/useCopyToClipboard.js
+++ b/agir/front/components/genericComponents/useCopyToClipboard.js
@@ -1,17 +1,30 @@
-import { useState, useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const useCopyToClipboard = (text = "", resetInterval = 5000) => {
   const [isCopied, setIsCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
     if (
-      typeof navigator.clipboard === "undefined" ||
-      typeof text !== "string"
+      typeof text !== "string" ||
+      typeof window === "undefined" ||
+      (typeof navigator.clipboard === "undefined" &&
+        typeof document.execCommand === "undefined")
     ) {
-      setIsCopied(false);
-      console.error(`Cannot copy ${typeof text} to clipboard.`);
       return;
     }
+
+    if (typeof navigator.clipboard === "undefined") {
+      const inputEl = document.createElement("input");
+      inputEl.value = text;
+      inputEl.width = "0";
+      inputEl.height = "0";
+      document.body.appendChild(inputEl);
+      inputEl.select();
+      setIsCopied(document.execCommand("copy"));
+      document.body.removeChild(inputEl);
+      return;
+    }
+
     navigator.clipboard
       .writeText(String(text))
       .then(() => {


### PR DESCRIPTION
Add a fallback inside `useCopyToClipboard` custom hook in case `navigator.clipboard` is not available.