### PR TITLE
Group Page / missing message author displayName handling

### DIFF
--- a/agir/front/components/formComponents/Comment.js
+++ b/agir/front/components/formComponents/Comment.js
@@ -200,7 +200,9 @@ const Comment = (props) => {
       <StyledMessage>
         <StyledMessageContent>
           <StyledMessageHeader>
-            <strong>{author.displayName}</strong>
+            <strong>
+              {author.displayName || (isAuthor && "Moi") || "Quelqu'un"}
+            </strong>
             <em>{created ? timeAgo(created) : null}</em>
           </StyledMessageHeader>
           <article>

--- a/agir/front/components/formComponents/Comment.js
+++ b/agir/front/components/formComponents/Comment.js
@@ -8,6 +8,7 @@ import { timeAgo } from "@agir/lib/utils/time";
 
 import Avatar from "@agir/front/genericComponents/Avatar";
 import { RawFeatherIcon } from "@agir/front/genericComponents/FeatherIcon";
+import Link from "@agir/front/app/Link";
 import InlineMenu from "@agir/front/genericComponents/InlineMenu";
 
 const StyledInlineMenuItems = styled.div`
@@ -118,14 +119,23 @@ const StyledWrapper = styled(animated.div)`
     font-size: 0.875rem;
     display: flex;
     flex-direction: row;
+    align-items: baseline;
 
     @media (max-width: ${style.collapse}px) {
       flex-direction: column;
+      align-items: flex-start;
     }
 
     strong {
-      font-weight: 600;
-      font-size: inherit;
+      font-weight: 700;
+      font-size: 0.875rem;
+
+      a {
+        margin-left: 0.25rem;
+        text-decoration: underline;
+        font-weight: 500;
+        line-height: inherit;
+      }
     }
 
     em {
@@ -202,6 +212,9 @@ const Comment = (props) => {
           <StyledMessageHeader>
             <strong>
               {author.displayName || (isAuthor && "Moi") || "Quelqu'un"}
+              {!author.displayName && isAuthor && (
+                <Link route="personalInformation">Ajouter mon nom</Link>
+              )}
             </strong>
             <em>{created ? timeAgo(created) : null}</em>
           </StyledMessageHeader>

--- a/agir/front/components/genericComponents/MessageCard.js
+++ b/agir/front/components/genericComponents/MessageCard.js
@@ -166,10 +166,19 @@ const StyledHeader = styled.div`
     font-size: inherit;
     display: flex;
     flex-flow: column nowrap;
+    font-size: 0.875rem;
 
     strong {
-      font-weight: 600;
+      font-weight: 700;
       font-size: inherit;
+      vertical-align: baseline;
+
+      a {
+        margin-left: 0.25rem;
+        text-decoration: underline;
+        font-weight: 500;
+        line-height: inherit;
+      }
     }
 
     em {
@@ -411,6 +420,10 @@ const MessageCard = (props) => {
           <h4>
             <strong>
               {author.displayName || (isAuthor && "Moi") || "Quelqu'un"}
+              &nbsp;
+              {!author.displayName && isAuthor && (
+                <Link route="personalInformation">Ajouter mon nom</Link>
+              )}
             </strong>
             <em onClick={handleClick} style={{ cursor: "pointer" }}>
               {created ? timeAgo(created) : null}

--- a/agir/front/components/genericComponents/MessageCard.js
+++ b/agir/front/components/genericComponents/MessageCard.js
@@ -409,7 +409,9 @@ const MessageCard = (props) => {
         <StyledHeader>
           <Avatar {...author} />
           <h4>
-            <strong>{author.displayName}</strong>
+            <strong>
+              {author.displayName || (isAuthor && "Moi") || "Quelqu'un"}
+            </strong>
             <em onClick={handleClick} style={{ cursor: "pointer" }}>
               {created ? timeAgo(created) : null}
             </em>

--- a/agir/msgs/serializers.py
+++ b/agir/msgs/serializers.py
@@ -12,9 +12,15 @@ from agir.people.serializers import PersonSerializer
 class BaseMessageSerializer(FlexibleFieldsMixin, serializers.ModelSerializer):
     id = serializers.UUIDField(read_only=True)
     created = serializers.DateTimeField(read_only=True)
-    author = PersonSerializer(read_only=True, fields=["id", "displayName"])
+    author = serializers.SerializerMethodField()
     text = serializers.CharField()
     image = serializers.ImageField(required=False)
+
+    def get_author(self, obj):
+        return {
+            "id": str(obj.author.id),
+            "displayName": obj.author.get_display_name(fallback=""),
+        }
 
 
 class MessageCommentSerializer(BaseMessageSerializer):

--- a/agir/people/models.py
+++ b/agir/people/models.py
@@ -485,9 +485,9 @@ class Person(
         if not value and self.subscribed:
             self.newsletters.remove(self.NEWSLETTER_LFI)
 
-    def get_display_name(self):
+    def get_display_name(self, fallback="Quelqu'un"):
         full_name = "%s %s" % (self.first_name, self.last_name)
-        return full_name.strip() or "Quelqu'un"
+        return full_name.strip() or fallback
 
     def get_full_name(self):
         """


### PR DESCRIPTION
- gérer le fallback pour le displayName de l'auteur d'un message côté frontend
- ajouter un lien vers la page de profil dans les messages/commentaires de l'utilisateur connecté si celui-ci n'a pas de displayName