### PR TITLE
Add new member email to activity payload

### DIFF
--- a/agir/activity/components/page__requiredActivities/RequiredActionCard.js
+++ b/agir/activity/components/page__requiredActivities/RequiredActionCard.js
@@ -173,7 +173,7 @@ const RequiredActionCard = (props) => {
   }, [id, status, onDismiss]);
 
   const [isEmailCopied, copyEmail] = useCopyToClipboard(
-    (individual && individual.email) || "",
+    (meta && meta.email) || "",
     1000
   );
 

--- a/agir/groups/actions/notifications.py
+++ b/agir/groups/actions/notifications.py
@@ -21,6 +21,7 @@ def someone_joined_notification(membership, membership_count=1):
                 recipient=r,
                 supportgroup=membership.supportgroup,
                 individual=membership.person,
+                meta={"email": membership.person.email},
             )
             for r in recipients
         ]


### PR DESCRIPTION
Nous avons supprimé le champs `email` du serializer d'activités pour la propriété `individual`, pour des raisons de confidentialité, mais ce champs était nécessaire pour l'activité de type `new-member`, dans laquelle on invite les animateurs d'un group d'action à envoyer un email à la personne qui a rejoint le groupe.