### PR TITLE
Allow configuration of protected frontend routes

### DIFF
--- a/agir/front/components/app/App.js
+++ b/agir/front/components/app/App.js
@@ -5,10 +5,12 @@ import { GlobalContextProvider } from "@agir/front/globalContext/GlobalContext";
 import Router from "./Router";
 import TopBar from "@agir/front/allPages/TopBar";
 import PushModal from "@agir/front/allPages/PushModal";
+import ConnectivityWarning from "@agir/front/app/ConnectivityWarning";
 
 export default function App() {
   return (
     <GlobalContextProvider>
+      <ConnectivityWarning />
       <Router>
         <Helmet>
           <title>Plateforme d'action - Action populaire</title>

--- a/agir/front/components/app/Page.js
+++ b/agir/front/components/app/Page.js
@@ -1,0 +1,102 @@
+import PropTypes from "prop-types";
+import React, { Suspense, useEffect, useMemo } from "react";
+import { useHistory, useLocation, useParams } from "react-router-dom";
+
+import {
+  useDispatch,
+  useSelector,
+} from "@agir/front/globalContext/GlobalContext";
+import { getIsSessionLoaded } from "@agir/front/globalContext/reducers";
+import {
+  setBackLink,
+  setTopBarRightLink,
+  setAdminLink,
+} from "@agir/front/globalContext/actions";
+
+import Layout from "@agir/front/dashboardComponents/Layout";
+import FeedbackButton from "@agir/front/allPages/FeedbackButton";
+import ErrorBoundary from "./ErrorBoundary";
+import logger from "@agir/lib/utils/logger";
+import useTracking from "./useTracking";
+
+const log = logger(__filename);
+
+const Page = (props) => {
+  const { Component, routeConfig, ...rest } = props;
+
+  const dispatch = useDispatch();
+  const isSessionLoaded = useSelector(getIsSessionLoaded);
+  const history = useHistory();
+  const routeParams = useParams();
+  const { pathname } = useLocation();
+
+  useTracking();
+
+  useEffect(() => {
+    isSessionLoaded &&
+      routeConfig.backLink &&
+      dispatch(setBackLink(routeConfig.backLink));
+  }, [pathname, isSessionLoaded, dispatch, routeConfig.backLink]);
+
+  useEffect(() => {
+    let unlisten = history.listen((location, action) => {
+      log.debug(
+        `Navigate ${action} ${location.pathname}${location.search}${location.hash}`,
+        JSON.stringify(history, null, 2)
+      );
+    });
+
+    return () => unlisten();
+  }, [history]);
+
+  useMemo(() => {
+    typeof window !== "undefined" && window.scrollTo && window.scrollTo(0, 0);
+  }, []);
+
+  useMemo(() => {
+    dispatch(setBackLink(null));
+    dispatch(setTopBarRightLink(null));
+    dispatch(setAdminLink(null));
+    //eslint-disable-next-line
+  }, [pathname]);
+
+  if (!routeConfig.hasLayout) {
+    return (
+      <ErrorBoundary>
+        <Suspense fallback={<div />}>
+          <Component
+            {...(routeConfig.routeProps || {})}
+            {...routeParams}
+            {...rest}
+            data={[]}
+          />
+          {routeConfig.hideFeedbackButton ? null : (
+            <FeedbackButton style={{ bottom: "1rem" }} />
+          )}
+        </Suspense>
+      </ErrorBoundary>
+    );
+  }
+
+  return (
+    <Layout {...(routeConfig.layoutProps || {})} active={routeConfig.id}>
+      <ErrorBoundary>
+        <Suspense fallback={<div />}>
+          <Component
+            {...(routeConfig.routeProps || {})}
+            {...routeParams}
+            {...rest}
+            data={[]}
+          />
+          {routeConfig.hideFeedbackButton ? null : <FeedbackButton />}
+        </Suspense>
+      </ErrorBoundary>
+    </Layout>
+  );
+};
+Page.propTypes = {
+  Component: PropTypes.elementType.isRequired,
+  routeConfig: PropTypes.object.isRequired,
+};
+
+export default Page;

--- a/agir/front/components/app/Router.js
+++ b/agir/front/components/app/Router.js
@@ -1,117 +1,36 @@
 import PropTypes from "prop-types";
-import React, { Suspense, useEffect, useMemo } from "react";
+import React from "react";
 import {
   BrowserRouter,
+  Redirect,
   Route,
   Switch,
-  useHistory,
   useLocation,
-  useParams,
 } from "react-router-dom";
 
-import {
-  useDispatch,
-  useSelector,
-} from "@agir/front/globalContext/GlobalContext";
-import { getIsSessionLoaded } from "@agir/front/globalContext/reducers";
-import {
-  setBackLink,
-  setTopBarRightLink,
-  setAdminLink,
-} from "@agir/front/globalContext/actions";
-
-import Layout from "@agir/front/dashboardComponents/Layout";
-import FeedbackButton from "@agir/front/allPages/FeedbackButton";
-import ErrorBoundary from "./ErrorBoundary";
-import routes, { BASE_PATH } from "./routes.config";
-import logger from "@agir/lib/utils/logger";
-import useTracking from "./useTracking";
+import routes, { routeConfig, BASE_PATH } from "./routes.config";
+import Page from "./Page";
 import NotFoundPage from "@agir/front/offline/NotFoundPage";
-import ConnectivityWarning from "@agir/front/app/ConnectivityWarning";
 
-const log = logger(__filename);
+import { useAuthentication } from "@agir/front/authentication/hooks";
 
-const Page = (props) => {
-  const history = useHistory();
-  const { Component, routeConfig, ...rest } = props;
-  const routeParams = useParams();
-  const dispatch = useDispatch();
-  const isSessionLoaded = useSelector(getIsSessionLoaded);
-  const { pathname } = useLocation();
-
-  useTracking();
-
-  useEffect(() => {
-    isSessionLoaded &&
-      routeConfig.backLink &&
-      dispatch(setBackLink(routeConfig.backLink));
-  }, [pathname, isSessionLoaded, dispatch, routeConfig.backLink]);
-
-  useEffect(() => {
-    let unlisten = history.listen((location, action) => {
-      log.debug(
-        `Navigate ${action} ${location.pathname}${location.search}${location.hash}`,
-        JSON.stringify(history, null, 2)
-      );
-    });
-
-    return () => unlisten();
-  }, [history]);
-
-  useMemo(() => {
-    typeof window !== "undefined" && window.scrollTo && window.scrollTo(0, 0);
-  }, []);
-
-  useMemo(() => {
-    dispatch(setBackLink(null));
-    dispatch(setTopBarRightLink(null));
-    dispatch(setAdminLink(null));
-    //eslint-disable-next-line
-  }, [pathname]);
-
-  if (!routeConfig.hasLayout) {
-    return (
-      <>
-        <ConnectivityWarning />
-        <ErrorBoundary>
-          <Suspense fallback={<div />}>
-            <Component
-              {...(routeConfig.routeProps || {})}
-              {...routeParams}
-              {...rest}
-              data={[]}
-            />
-            {routeConfig.hideFeedbackButton ? null : (
-              <FeedbackButton style={{ bottom: "1rem" }} />
-            )}
-          </Suspense>
-        </ErrorBoundary>
-      </>
-    );
+const ProtectedPage = (props) => {
+  const location = useLocation();
+  const isAuthorized = useAuthentication(props.routeConfig);
+  if (isAuthorized === null) {
+    return null;
   }
-
+  if (isAuthorized === true) {
+    return <Page {...props} />;
+  }
   return (
-    <>
-      <ConnectivityWarning />
-      <Layout {...(routeConfig.layoutProps || {})} active={routeConfig.id}>
-        <ErrorBoundary>
-          <Suspense fallback={<div />}>
-            <Component
-              {...(routeConfig.routeProps || {})}
-              {...routeParams}
-              {...rest}
-              data={[]}
-            />
-            {routeConfig.hideFeedbackButton ? null : <FeedbackButton />}
-          </Suspense>
-        </ErrorBoundary>
-      </Layout>
-    </>
+    <Redirect
+      to={{ pathname: routeConfig.login.pathname, state: { from: location } }}
+    />
   );
 };
-Page.propTypes = {
-  Component: PropTypes.elementType.isRequired,
-  routeConfig: PropTypes.object.isRequired,
+ProtectedPage.propTypes = {
+  routeConfig: PropTypes.object,
 };
 
 const Router = ({ children }) => (
@@ -119,7 +38,7 @@ const Router = ({ children }) => (
     <Switch>
       {routes.map((route) => (
         <Route key={route.id} path={route.pathname} exact={!!route.exact}>
-          <Page Component={route.Component} routeConfig={route} />
+          <ProtectedPage Component={route.Component} routeConfig={route} />
         </Route>
       ))}
       <Route key="not-found">

--- a/agir/front/components/app/routes.config.js
+++ b/agir/front/components/app/routes.config.js
@@ -27,6 +27,8 @@ const RequiredActivityPage = lazy(() =>
 const NavigationPage = lazy(() =>
   import("@agir/front/navigationPage/NavigationPage")
 );
+const LoginPage = lazy(() => import("@agir/front/authentication/LoginPage"));
+const SignupPage = lazy(() => import("@agir/front/authentication/SignupPage"));
 
 export const BASE_PATH = "/";
 
@@ -80,6 +82,7 @@ export const routeConfig = {
     id: "events",
     pathname: "/",
     exact: true,
+    protected: true,
     label: "Événements",
     Component: AgendaPage,
     hasLayout: true,
@@ -92,6 +95,7 @@ export const routeConfig = {
     id: "eventMap",
     pathname: "/evenements/carte/",
     exact: true,
+    protected: false,
     label: "Carte des événements",
     Component: EventMap,
   }),
@@ -99,6 +103,7 @@ export const routeConfig = {
     id: "eventDetails",
     pathname: "/evenements/:eventPk/",
     exact: true,
+    protected: false,
     label: "Details de l'événement",
     Component: EventPage,
     backLink: {
@@ -111,6 +116,7 @@ export const routeConfig = {
     id: "groups",
     pathname: "/mes-groupes/",
     exact: true,
+    protected: true,
     label: "Groupes",
     Component: GroupsPage,
     hasLayout: true,
@@ -122,6 +128,8 @@ export const routeConfig = {
     id: "groupMap",
     pathname: "/groupes/carte/",
     exact: true,
+    // TODO: set to false
+    protected: true,
     label: "Carte des groupes",
     Component: GroupMap,
   }),
@@ -129,6 +137,7 @@ export const routeConfig = {
     id: "fullGroup",
     pathname: "/groupes/:groupPk/complet/",
     exact: true,
+    protected: false,
     label: "Groupe complet",
     Component: FullGroupPage,
     hasLayout: false,
@@ -137,6 +146,7 @@ export const routeConfig = {
     id: "groupMessage",
     pathname: "/groupes/:groupPk/messages/:messagePk/",
     exact: true,
+    protected: true,
     label: "Message du groupe",
     Component: GroupMessagePage,
     hideFeedbackButton: true,
@@ -145,6 +155,7 @@ export const routeConfig = {
     id: "groupDetails",
     pathname: "/groupes/:groupPk/:activeTab?/",
     exact: true,
+    protected: false,
     label: "Details du groupe",
     Component: GroupPage,
     backLink: {
@@ -157,6 +168,7 @@ export const routeConfig = {
     id: "activities",
     pathname: "/activite/",
     exact: true,
+    protected: true,
     label: "Actualités",
     Component: ActivityPage,
     hasLayout: true,
@@ -170,6 +182,7 @@ export const routeConfig = {
     id: "requiredActivities",
     pathname: "/a-traiter/",
     exact: true,
+    protected: true,
     label: "À traiter",
     Component: RequiredActivityPage,
     hasLayout: true,
@@ -178,12 +191,29 @@ export const routeConfig = {
     id: "menu",
     pathname: "/navigation/",
     exact: true,
+    protected: true,
     label: "Menu",
     Component: NavigationPage,
     hasLayout: true,
     layoutProps: {
       desktopOnlyFooter: false,
     },
+  }),
+  login: new RouteConfig({
+    id: "login",
+    pathname: "/connexion/",
+    exact: true,
+    protected: false,
+    label: "Connexion",
+    Component: LoginPage,
+  }),
+  signup: new RouteConfig({
+    id: "signup",
+    pathname: "/inscription/",
+    exact: true,
+    protected: false,
+    label: "Inscription",
+    Component: SignupPage,
   }),
 };
 

--- a/agir/front/components/authentication/LoginPage.js
+++ b/agir/front/components/authentication/LoginPage.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+const LoginPage = () => {
+  const location = useLocation();
+  return (
+    <div>
+      <h1>Connexion !</h1>
+      {location.state.from && location.state.from.pathname && (
+        <p>
+          Next = <strong>{location.state.from.pathname}</strong>
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/agir/front/components/authentication/SignupPage.js
+++ b/agir/front/components/authentication/SignupPage.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const SignupPage = () => {
+  return <div>Inscription !</div>;
+};
+
+export default SignupPage;

--- a/agir/front/components/authentication/hooks.js
+++ b/agir/front/components/authentication/hooks.js
@@ -1,0 +1,20 @@
+import { useSelector } from "@agir/front/globalContext/GlobalContext";
+import {
+  getIsSessionLoaded,
+  getIsConnected,
+} from "@agir/front/globalContext/reducers";
+
+export const useAuthentication = (route) => {
+  const isSessionLoaded = useSelector(getIsSessionLoaded);
+  const isUserAuthenticated = useSelector(getIsConnected);
+
+  if (route.protected === false) {
+    return true;
+  }
+
+  if (!isSessionLoaded) {
+    return null;
+  }
+
+  return !!isUserAuthenticated;
+};

--- a/agir/front/components/offline/NotFoundPage.js
+++ b/agir/front/components/offline/NotFoundPage.js
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 
 import illustration from "./illustration.svg";
 import styled from "styled-components";
-import useSWR from "swr";
+
 import { useIsOffline } from "@agir/front/offline/hooks";
 
 const PageStyle = styled.div`


### PR DESCRIPTION
- Split out Page component from Router module
- Move ConnectivityWarning from Page to App component
- Add a boolean `protected` property to the route config objects
- Use the protected property from each route config to display the route component or
  redirect to the login route
- Add login and signup routes to frontend router config (WIP)