### PR TITLE
fix: restore default event image/description

### DIFF
--- a/agir/events/models.py
+++ b/agir/events/models.py
@@ -211,6 +211,12 @@ report_image_path = FilePattern(
 
 class EventManager(models.Manager.from_queryset(EventQuerySet)):
     def create(self, *args, **kwargs):
+        subtype = kwargs.get("subtype", None)
+        if subtype:
+            kwargs["description"] = kwargs.get(
+                "description", subtype.default_description
+            )
+            kwargs["image"] = kwargs.get("image", subtype.default_image)
         return self.create_event(*args, **kwargs)
 
     def create_event(


### PR DESCRIPTION
- À la création d'un événement, définir une description et une image par défaut si celles-ci sont définies pour le sous-type de l'événement (régression depuis la nouvelle création d'événement)