### PR TITLE
vagrant install node version 14.x

### DIFF
--- a/vagrant.sh
+++ b/vagrant.sh
@@ -29,6 +29,8 @@ fi
 
 echo "## Install node..."
 if ! dpkg -s nodejs &> /dev/null; then
+    curl -sL https://deb.nodesource.com/setup_14.x -o /tmp/nodesource_setup.sh &> /dev/null
+    sudo bash /tmp/nodesource_setup.sh &> /dev/null
     sudo apt-get -yqq install nodejs > /dev/null
 fi
 


### PR DESCRIPTION
Node version available on Ubuntu repositories is too old for launching webpack commands in the VM, this PR install 14.X branch of node JS in the vagrant machine