### PR TITLE
fix typo on eslint command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ be ran from inside the `/vagrant` folder in the vagrant box).
 
 ```bash
 $ black agir/
-$ node_modules/.bin/esling --fix agir/
+$ node_modules/.bin/eslint --fix agir/
 $ pipenv run ./manage.py test
 ``` 
 


### PR DESCRIPTION
Fix for a typo who could be painful in a copy and paste