### PR TITLE
Default person notification subscriptions

### DIFF
--- a/agir/activity/components/common/notificationSettings/NotificationSettings.js
+++ b/agir/activity/components/common/notificationSettings/NotificationSettings.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useHistory, useRouteMatch } from "react-router-dom";
 import useSWR from "swr";
 
@@ -20,7 +20,7 @@ const NotificationSettings = (props) => {
   const { available, isSubscribed, subscribe, unsubscribe } = usePush();
 
   const { data: groupData } = useSWR("/api/groupes/");
-  const { data: userNotifications, mutate } = useSWR(
+  const { data: userNotifications, mutate, isValidating } = useSWR(
     api.ENDPOINT.getSubscriptions
   );
 
@@ -68,13 +68,17 @@ const NotificationSettings = (props) => {
     [mutate]
   );
 
+  useEffect(() => {
+    mutate();
+  }, [mutate, isSubscribed]);
+
   return (
     <NotificationSettingPanel
       {...props}
       notifications={notifications}
       activeNotifications={activeNotifications}
       onChange={handleChange}
-      disabled={isLoading}
+      disabled={isLoading || isValidating}
       ready={!!userNotifications && !!groupData}
       subscribeDevice={available && !isSubscribed ? subscribe : undefined}
       unsubscribeDevice={available && isSubscribed ? unsubscribe : undefined}

--- a/agir/notifications/actions.py
+++ b/agir/notifications/actions.py
@@ -1,0 +1,89 @@
+from agir.activity.models import Activity
+from agir.groups.models import Membership
+from agir.notifications.models import Subscription
+
+DEFAULT_PERSON_SUBSCRIPTION_ACTIVITY_TYPES = [
+    Activity.TYPE_GROUP_INVITATION,
+    Activity.TYPE_WAITING_LOCATION_EVENT,
+    Activity.TYPE_NEW_ATTENDEE,
+    Activity.TYPE_EVENT_UPDATE,
+    Activity.TYPE_CANCELLED_EVENT,
+    Activity.TYPE_REFERRAL,
+    Activity.TYPE_TRANSFERRED_GROUP_MEMBER,
+    Activity.TYPE_WAITING_PAYMENT,
+    Activity.TYPE_NEW_EVENT_AROUNDME,
+]
+
+DEFAULT_GROUP_SUBSCRIPTION_ACTIVITY_TYPES = [
+    Activity.TYPE_GROUP_COORGANIZATION_INFO,
+    Activity.TYPE_NEW_MESSAGE,
+    Activity.TYPE_NEW_COMMENT,
+    Activity.TYPE_GROUP_INFO_UPDATE,
+    Activity.TYPE_NEW_EVENT_MYGROUPS,
+    Activity.TYPE_NEW_REPORT,
+    Activity.TYPE_GROUP_COORGANIZATION_ACCEPTED,
+    Activity.TYPE_GROUP_COORGANIZATION_INVITE,
+    Activity.TYPE_WAITING_LOCATION_GROUP,
+    Activity.TYPE_NEW_MEMBER,
+    Activity.TYPE_ACCEPTED_INVITATION_MEMBER,
+    Activity.TYPE_GROUP_MEMBERSHIP_LIMIT_REMINDER,
+    Activity.TYPE_NEW_MEMBERS_THROUGH_TRANSFER,
+]
+
+
+def get_default_person_subscriptions(person):
+    subscriptions = []
+
+    for activity_type in DEFAULT_PERSON_SUBSCRIPTION_ACTIVITY_TYPES:
+        subscriptions += [
+            Subscription(
+                person=person,
+                type=Subscription.SUBSCRIPTION_EMAIL,
+                activity_type=activity_type,
+            ),
+            Subscription(
+                person=person,
+                type=Subscription.SUBSCRIPTION_PUSH,
+                activity_type=activity_type,
+            ),
+        ]
+
+    return subscriptions
+
+
+def get_default_group_subscriptions(person, membership):
+    subscriptions = []
+
+    for activity_type in DEFAULT_GROUP_SUBSCRIPTION_ACTIVITY_TYPES:
+        subscriptions += [
+            Subscription(
+                person=person,
+                type=Subscription.SUBSCRIPTION_EMAIL,
+                activity_type=activity_type,
+                membership=membership,
+            ),
+            Subscription(
+                person=person,
+                type=Subscription.SUBSCRIPTION_PUSH,
+                activity_type=activity_type,
+                membership=membership,
+            ),
+        ]
+
+    return subscriptions
+
+
+def create_default_person_subscriptions(person):
+    subscriptions = get_default_person_subscriptions(person)
+    person_memberships = Membership.objects.filter(person=person).distinct()
+
+    if person_memberships.exists():
+        for membership in person_memberships:
+            subscriptions += get_default_group_subscriptions(person, membership)
+
+    Subscription.objects.bulk_create(subscriptions)
+
+
+def create_default_group_membership_subscriptions(person, membership):
+    subscriptions = get_default_group_subscriptions(person, membership)
+    Subscription.objects.bulk_create(subscriptions)

--- a/agir/notifications/components/common/notifications.config.js
+++ b/agir/notifications/components/common/notifications.config.js
@@ -280,7 +280,7 @@ export const getNotificationStatus = (activeNotifications) => {
     }
     notificationId = getNotificationId(
       notification.id,
-      activeNotification.group?.id
+      activeNotification.group
     );
     active[notificationId] = active[notificationId] || {
       email: false,

--- a/agir/notifications/serializers/subscriptions.py
+++ b/agir/notifications/serializers/subscriptions.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-class SubscriptionSupportGroupSerializer(SupportGroupSerializer):
+class SubscriptionSupportGroupSerializer(serializers.UUIDField):
     def to_internal_value(self, data):
         if data is None:
             return data
@@ -47,16 +47,20 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         source="activity_type",
     )
     group = SubscriptionSupportGroupSerializer(
-        source="membership.supportgroup", default=None, allow_null=True, required=False
+        source="membership.supportgroup_id",
+        default=None,
+        allow_null=True,
+        required=False,
     )
 
     def validate(self, data):
         membership = data.pop("membership", None)
         data["membership"] = None
-        if membership is not None and membership["supportgroup"] is not None:
+
+        if membership is not None and membership["supportgroup_id"] is not None:
             try:
                 data["membership"] = Membership.objects.get(
-                    supportgroup=membership["supportgroup"], person=data["person"],
+                    supportgroup=membership["supportgroup_id"], person=data["person"],
                 )
             except Membership.DoesNotExist:
                 raise serializers.ValidationError({"group": "Invalid group"})

--- a/agir/notifications/tests/test_api_views.py
+++ b/agir/notifications/tests/test_api_views.py
@@ -1,4 +1,5 @@
 import uuid
+from django.db.models import signals
 from rest_framework.test import APITestCase
 
 from agir.activity.models import Activity
@@ -9,6 +10,9 @@ from agir.people.models import Person
 
 class ListSubscriptionsAPITestCase(APITestCase):
     def setUp(self):
+        signals.post_save.disconnect(
+            sender=Membership, dispatch_uid="create_default_membership_subscriptions"
+        )
         self.person = Person.objects.create(
             email="person@example.com", create_role=True
         )
@@ -48,6 +52,9 @@ class ListSubscriptionsAPITestCase(APITestCase):
 
 class CreateSubscriptionsAPITestCase(APITestCase):
     def setUp(self):
+        signals.post_save.disconnect(
+            sender=Membership, dispatch_uid="create_default_membership_subscriptions"
+        )
         self.person = Person.objects.create(
             email="person@example.com", create_role=True
         )
@@ -186,6 +193,9 @@ class CreateSubscriptionsAPITestCase(APITestCase):
 
 class DeleteSubscriptionsAPITestCase(APITestCase):
     def setUp(self):
+        signals.post_save.disconnect(
+            sender=Membership, dispatch_uid="create_default_membership_subscriptions"
+        )
         self.person = Person.objects.create(
             email="person@example.com", create_role=True
         )

--- a/agir/notifications/views.py
+++ b/agir/notifications/views.py
@@ -13,7 +13,9 @@ class ListCreateDestroySubscriptionAPIView(ListCreateAPIView, DestroyAPIView):
     queryset = Subscription.objects.all()
 
     def get_queryset(self):
-        return self.queryset.filter(person=self.request.user.person)
+        return self.queryset.filter(person=self.request.user.person).prefetch_related(
+            "membership"
+        )
 
     def get_object(self):
         if self.request.method == "DELETE":


### PR DESCRIPTION
- Fix SubscriptionSerializer performances (~9s to ~500ms for a GET request)
- Add post_save signals to WebPushDevice and Membership models to automatically create the default subscriptions for the current user (if none is already present)