### PR TITLE
Attempt-to-fix: android firefox push manager subscription

### DIFF
--- a/agir/notifications/components/push/utils.js
+++ b/agir/notifications/components/push/utils.js
@@ -48,6 +48,7 @@ export async function doSubscribe(serviceWorkerRegistration, pushSubscription) {
       "WEBPUSH_PUBLIC_KEY must be define. You can generate keys at https://web-push-codelab.glitch.me/."
     );
   }
+
   pushSubscription =
     pushSubscription ||
     (await serviceWorkerRegistration.pushManager.subscribe({
@@ -55,7 +56,8 @@ export async function doSubscribe(serviceWorkerRegistration, pushSubscription) {
       applicationServerKey: urlBase64ToUint8Array(
         process.env.WEBPUSH_PUBLIC_KEY
       ),
-    }));
+    })) ||
+    (await serviceWorkerRegistration.pushManager.getSubscription());
 
   log.debug("Received PushSubscription: ", pushSubscription);
 


### PR DESCRIPTION
Tentative de fix d'un bug sur Firefox Android qui empêche la subscription au pushManager :
![image](https://user-images.githubusercontent.com/29723122/114679710-b6625c80-9d0c-11eb-998a-04c28d5057ec.png)
Selon ce tableau sur [MDN](https://developer.mozilla.org/en-US/docs/Web/API/PushManager/subscribe), le push est activé par défaut sur Firefox Android, ce qui peut-être rend inutile l'appel à la method `subscribe`. Un fallback vers la method `getSubscription` du `pushManager` pourrait, peut-être résoudre ce problème.

@jillro Qu'en penses-tu ?
