### PR TITLE
fix: MobileAppModal layout and links

### DIFF
--- a/agir/front/components/allPages/PushModal/MobileAppModal.js
+++ b/agir/front/components/allPages/PushModal/MobileAppModal.js
@@ -35,7 +35,7 @@ const StyledModalContent = styled.div`
   @media (max-width: ${style.collapse}px) {
     margin-top: 20px;
     max-width: calc(100% - 40px);
-    padding: 3rem 0;
+    padding: 0 0 1.5rem;
   }
 
   & > * {
@@ -72,6 +72,11 @@ const StyledModalContent = styled.div`
     background-repeat: no-repeat;
     margin-bottom: 56px;
 
+    @media (max-width: ${style.collapse}px) {
+      height: 100px;
+      background-size: 160px auto;
+    }
+
     &::after {
       content: "";
       display: block;
@@ -85,10 +90,6 @@ const StyledModalContent = styled.div`
       bottom: 0;
       left: 50%;
       transform: translate3d(-50%, 50%, 0);
-    }
-
-    @media (max-width: ${style.collapse}px) {
-      display: none;
     }
   }
 
@@ -110,6 +111,10 @@ const StyledModalContent = styled.div`
     font-size: 1rem;
     line-height: 1.6;
     padding-bottom: 2.5rem;
+
+    @media (max-width: ${style.collapse}px) {
+      font-size: 0.875rem;
+    }
   }
 
   ${Buttons} {
@@ -123,14 +128,9 @@ const StyledModalContent = styled.div`
   }
 `;
 
-const UTM_PARAMS = {
-  utm_source: "ap",
-  utm_campaign: "mobile-app-modal",
-};
-
 export const MobileAppModal = ({ shouldShow = false, onClose }) => {
   return (
-    <Modal shouldShow={shouldShow}>
+    <Modal shouldShow={shouldShow} onClose={onClose}>
       <StyledModalContent>
         <CloseButton onClick={onClose} aria-label="Fermer la modale">
           <RawFeatherIcon name="x" width="2rem" height="2rem" />
@@ -143,9 +143,9 @@ export const MobileAppModal = ({ shouldShow = false, onClose }) => {
           aucune information près de chez vous !
         </p>
         <Buttons>
-          <AppStore type="google" params={UTM_PARAMS} />
+          <AppStore type="google" />
           <Spacer size="1rem" />
-          <AppStore type="apple" params={UTM_PARAMS} />
+          <AppStore type="apple" />
         </Buttons>
       </StyledModalContent>
     </Modal>

--- a/agir/front/components/allPages/PushModal/MobileAppModal.stories.js
+++ b/agir/front/components/allPages/PushModal/MobileAppModal.stories.js
@@ -1,3 +1,4 @@
+import React from "react";
 import { MobileAppModal } from "./MobileAppModal";
 
 export default {
@@ -5,11 +6,10 @@ export default {
   title: "Layout/PushModal/MobileAppModal",
 };
 
-const Template = MobileAppModal;
+const Template = (args) => <MobileAppModal {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
   referralURL: "https://referral.url",
   shouldShow: true,
-  onClose: () => {},
 };

--- a/agir/front/components/genericComponents/AppStore.js
+++ b/agir/front/components/genericComponents/AppStore.js
@@ -1,27 +1,23 @@
-import React, { useMemo } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-
-import { addQueryStringParams } from "@agir/lib/utils/url";
 
 import APP_STORE_APPLE from "@agir/front/genericComponents/logos/appstore_apple.svg";
 import APP_STORE_GOOGLE from "@agir/front/genericComponents/logos/appstore_google.svg";
 
 const CONFIG = {
   apple: {
-    href: "https://infos.actionpopulaire.fr/application-ios",
+    href:
+      "https://apps.apple.com/us/app/action-populaire/id1559737444#?platform=iphone",
     title: "Télécharger dans l'App Store",
     $image: APP_STORE_APPLE,
   },
   google: {
-    href: "https://infos.actionpopulaire.fr/application-android",
+    href:
+      "https://play.google.com/store/apps/details?id=fr.actionpopulaire.twa",
     title: "Disponible sur Google Play",
     $image: APP_STORE_GOOGLE,
   },
-};
-
-const DEFAULT_UTM_PARAMS = {
-  utm_source: "ap",
 };
 
 const AppStoreLink = styled.a`
@@ -36,20 +32,14 @@ const AppStoreLink = styled.a`
 `;
 
 const AppStore = (props) => {
-  const { type, params, ...rest } = props;
+  const { type, ...rest } = props;
   const config = CONFIG[type];
-
-  const href = useMemo(() => {
-    if (config && config.href) {
-      return addQueryStringParams(config.href, params || DEFAULT_UTM_PARAMS);
-    }
-  }, [config, params]);
 
   if (!config) {
     return null;
   }
 
-  return <AppStoreLink {...config} {...rest} href={href} />;
+  return <AppStoreLink {...config} {...rest} />;
 };
 
 AppStore.propTypes = {


### PR DESCRIPTION
- Remove app store link redirections
- Allow closing of modal by clicking on the overlay
- Display header on small screens
