### PR TITLE
attempt-to-fix: page first load

### DIFF
--- a/agir/front/components/app/index.js
+++ b/agir/front/components/app/index.js
@@ -1,28 +1,23 @@
-import React, { Suspense } from "react";
+import React from "react";
 import onDOMReady from "@agir/lib/utils/onDOMReady";
 import logger from "@agir/lib/utils/logger";
 
 import "@agir/front/allPages/sentry";
 import "@agir/front/allPages/ios.js";
 import "@agir/front/genericComponents/style.scss";
+
 import { renderReactComponent } from "@agir/lib/utils/react";
-import { lazy } from "@agir/front/app/utils";
+
+import App from "@agir/front/app/App";
 
 const log = logger(__filename);
-
-const App = lazy(() => import("@agir/front/app/App"), null);
 
 const init = () => {
   const renderElement = document.getElementById("mainApp");
   if (!renderElement) {
     return;
   }
-  renderReactComponent(
-    <Suspense fallback={null}>
-      <App />
-    </Suspense>,
-    renderElement
-  );
+  renderReactComponent(<App />, renderElement);
 };
 onDOMReady(init);
 

--- a/agir/front/templates/front/react_view.html
+++ b/agir/front/templates/front/react_view.html
@@ -1,9 +1,5 @@
 {% extends "front/base_layout.html" %}
 
-{% block extra_scripts %}
-  {% include bundle_name|add:".bundle.html" %}
-{% endblock %}
-
 {% block additional_headers %}
 <link rel="preload" href="{% url "api_session" %}" as="fetch" crossorigin="anonymous">
 {% endblock %}
@@ -15,6 +11,7 @@
   {% if export_data %}
     {{ export_data|json_script:data_script_id }}
   {% endif %}
+  {% include bundle_name|add:".bundle.html" %}
 {% endblock %}
 
 


### PR DESCRIPTION
- Suppression du lazy-loading du composant racine App
- Déplacement des fichiers du bundle webpack à la fin du body: ce qui permet d'essayer précharger l'API session et aussi d'afficher le loader HTML pendant le chargement de ces fichiers