### PR TITLE
Fix keep the app loader visible until the first authentication

### DIFF
--- a/agir/front/components/app/Router.js
+++ b/agir/front/components/app/Router.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import {
   BrowserRouter,
   Redirect,
@@ -17,12 +17,30 @@ import { useAuthentication } from "@agir/front/authentication/hooks";
 export const ProtectedComponent = (props) => {
   const location = useLocation();
   const isAuthorized = useAuthentication(props.routeConfig);
+
+  useEffect(() => {
+    if (isAuthorized === null) {
+      return;
+    }
+    const loader = document.getElementById("app_loader");
+    if (!loader) {
+      return;
+    }
+    loader.style.opacity = "0";
+    loader.addEventListener("transitionend", () => {
+      const loader = document.getElementById("app_loader");
+      loader && loader.remove();
+    });
+  }, [isAuthorized]);
+
   if (isAuthorized === null) {
     return null;
   }
+
   if (isAuthorized === true) {
     return <Page {...props} />;
   }
+
   return (
     <Redirect
       to={{ pathname: routeConfig.login.path, state: { from: location } }}

--- a/agir/front/templates/front/includes/loader.html
+++ b/agir/front/templates/front/includes/loader.html
@@ -10,14 +10,25 @@
     stroke-dashoffset: 200;
     stroke-linecap: round;
     animation: dash 2s linear forwards infinite;
+    will-change: stroke-dashoffset;
   }
 
   #app_loader {
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
     width: 100vw;
     height: 100vh;
     display: flex;
     align-items: center;
     justify-content: center;
+    opacity: 1;
+    overflow: hidden;
+    transition: opacity 200ms ease-in-out;
+    z-index: 9999;
+    will-change: opacity;
   }
 </style>
 <div id="app_loader">

--- a/agir/front/templates/front/react_view.html
+++ b/agir/front/templates/front/react_view.html
@@ -5,9 +5,8 @@
 {% endblock %}
 
 {% block whole_page %}
-  <div id="{{ app_mount_id }}">
-    {% include "front/includes/loader.html" %}
-  </div>
+  {% include "front/includes/loader.html" %}
+  <div id="{{ app_mount_id }}"></div>
   {% if export_data %}
     {{ export_data|json_script:data_script_id }}
   {% endif %}


### PR DESCRIPTION
Ne pas supprimer le loader HTML dès que React est chargé, mais attendra que la vérification des droits de l'utilisateur à voir la page soit faite pour d'abord cacher puis supprimer le loader HTML 