### PR TITLE
Fix PushModal unwanted appearances

### DIFF
--- a/agir/front/components/allPages/PushModal/PushModal.js
+++ b/agir/front/components/allPages/PushModal/PushModal.js
@@ -43,15 +43,21 @@ export const PushModal = ({ isActive = true }) => {
   }, [dismissMobileAppAnnouncement]);
 
   useEffect(() => {
+    let displayTimeout;
     if (
-      !window.location.href.endsWith(routeConfig.tellMore.getLink()) &&
       isActive &&
       isSessionLoaded &&
       typeof shouldShow !== "boolean" &&
       (!!ReferralModalAnnouncement || !!MobileAppAnnouncement)
     ) {
-      setShouldShow(true);
+      displayTimeout = setTimeout(() => {
+        !window.location.href.endsWith(routeConfig.tellMore.getLink()) &&
+          setShouldShow(true);
+      }, 1000);
     }
+    return () => {
+      clearTimeout(displayTimeout);
+    };
   }, [
     shouldShow,
     isActive,


### PR DESCRIPTION
- Update useCustomAnnouncement hook to only mark an announcement as displayed once
- Update PushModal to wait 1000ms before displaying the modal (if needed) to allow an eventual redirection
  from the homepage to the tell-more page to happen before the modal appearance