### PR TITLE
Fix PushModal current location display condition

### DIFF
--- a/agir/front/components/allPages/PushModal/PushModal.js
+++ b/agir/front/components/allPages/PushModal/PushModal.js
@@ -51,7 +51,8 @@ export const PushModal = ({ isActive = true }) => {
       (!!ReferralModalAnnouncement || !!MobileAppAnnouncement)
     ) {
       displayTimeout = setTimeout(() => {
-        !window.location.href.endsWith(routeConfig.tellMore.getLink()) &&
+        window.location?.pathname &&
+          !routeConfig.tellMore.match(window.location.pathname) &&
           setShouldShow(true);
       }, 1000);
     }

--- a/agir/front/components/allPages/PushModal/PushModal.js
+++ b/agir/front/components/allPages/PushModal/PushModal.js
@@ -76,7 +76,7 @@ export const PushModal = ({ isActive = true }) => {
   return (
     <ReferralModal
       onClose={handleCloseReferral}
-      shouldShow={shouldShow}
+      shouldShow={!!ReferralModalAnnouncement && shouldShow}
       referralURL={
         isSessionLoaded && routes.nspReferral ? routes.nspReferral : ""
       }


### PR DESCRIPTION
Utiliser location.pathname au lieu de location.href pour cacher la PushModal sur la page /bievenue/, pour éviter que ça ne fonctionne pas lorsqu'il y a des paramètres ou un hash dans l'URL