### PR TITLE
Add post_save_task decorator on db-based async tasks

### DIFF
--- a/agir/checks/tasks.py
+++ b/agir/checks/tasks.py
@@ -3,18 +3,15 @@ from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 
 from agir.checks.models import CheckPayment
-from agir.lib.celery import emailing_task
+from agir.lib.celery import emailing_task, post_save_task
 from agir.lib.mailing import send_mosaico_email
 from agir.payments.payment_modes import PAYMENT_MODES
 
 
 @emailing_task
+@post_save_task
 def send_check_information(check_id, force=False):
-    try:
-        check = CheckPayment.objects.get(id=check_id)
-    except CheckPayment.DoesNotExist:
-        return
-
+    check = CheckPayment.objects.get(id=check_id)
     mail_sent = check.meta.get("information_email_sent")
 
     if mail_sent and not force:

--- a/agir/donations/tasks.py
+++ b/agir/donations/tasks.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 
 from agir.authentication.tokens import monthly_donation_confirmation_token_generator
 from agir.donations.models import SpendingRequest
-from agir.lib.celery import emailing_task, http_task
+from agir.lib.celery import emailing_task, http_task, post_save_task
 from agir.lib.mailing import send_mosaico_email, add_params_to_urls
 from agir.lib.phone_numbers import is_french_number, is_mobile_number
 from agir.lib.sms import send_sms
@@ -15,12 +15,9 @@ from agir.system_pay.models import SystemPaySubscription
 
 
 @emailing_task
+@post_save_task
 def send_donation_email(person_pk, template_code="DONATION_MESSAGE"):
-    try:
-        person = Person.objects.prefetch_related("emails").get(pk=person_pk)
-    except Person.DoesNotExist:
-        return
-
+    person = Person.objects.prefetch_related("emails").get(pk=person_pk)
     send_mosaico_email(
         code=template_code,
         subject="Merci d'avoir donné !",
@@ -31,13 +28,11 @@ def send_donation_email(person_pk, template_code="DONATION_MESSAGE"):
 
 
 @emailing_task
+@post_save_task
 def send_spending_request_to_review_email(spending_request_pk):
-    try:
-        spending_request = SpendingRequest.objects.prefetch_related("group").get(
-            pk=spending_request_pk
-        )
-    except SpendingRequest.DoesNotExist:
-        return
+    spending_request = SpendingRequest.objects.prefetch_related("group").get(
+        pk=spending_request_pk
+    )
 
     send_mosaico_email(
         code="SPENDING_REQUEST_TO_REVIEW_NOTIFICATION",
@@ -79,13 +74,11 @@ def send_monthly_donation_confirmation_email(email, **kwargs):
 
 
 @emailing_task
+@post_save_task
 def send_expiration_email_reminder(sp_subscription_pk):
-    try:
-        sp_subscription = SystemPaySubscription.objects.select_related(
-            "subscription__person", "alias"
-        ).get(pk=sp_subscription_pk)
-    except SystemPaySubscription.DoesNotExist:
-        return
+    sp_subscription = SystemPaySubscription.objects.select_related(
+        "subscription__person", "alias"
+    ).get(pk=sp_subscription_pk)
 
     send_mosaico_email(
         code="CARD_EXPIRATION",
@@ -101,13 +94,11 @@ def send_expiration_email_reminder(sp_subscription_pk):
 
 
 @http_task
+@post_save_task
 def send_expiration_sms_reminder(sp_subscription_pk):
-    try:
-        sp_subscription = SystemPaySubscription.objects.select_related(
-            "subscription__person", "alias"
-        ).get(pk=sp_subscription_pk)
-    except SystemPaySubscription.DoesNotExist:
-        return
+    sp_subscription = SystemPaySubscription.objects.select_related(
+        "subscription__person", "alias"
+    ).get(pk=sp_subscription_pk)
 
     recipient = sp_subscription.subscription.person
 

--- a/agir/events/tests/test_tasks.py
+++ b/agir/events/tests/test_tasks.py
@@ -188,14 +188,6 @@ class EventTasksTestCase(TestCase):
         tasks.geocode_event(self.event.pk)
         geocode_element.assert_called_once_with(self.event)
 
-    @patch("agir.events.tasks.geocode_element")
-    def test_geocode_event_does_not_call_geocode_element_if_event_does_not_exist(
-        self, geocode_element
-    ):
-        geocode_element.assert_not_called()
-        tasks.geocode_event(fake.uuid4())
-        geocode_element.assert_not_called()
-
     @patch(
         "agir.events.tasks.geocode_element",
         side_effect=mock_geocode_element_no_position,

--- a/agir/groups/tests/test_tasks.py
+++ b/agir/groups/tests/test_tasks.py
@@ -337,14 +337,6 @@ class NotificationTasksTestCase(TestCase):
         tasks.geocode_support_group(self.group.pk)
         geocode_element.assert_called_once_with(self.group)
 
-    @patch("agir.groups.tasks.geocode_element")
-    def test_geocode_support_group_does_not_call_geocode_element_if_group_does_not_exist(
-        self, geocode_element
-    ):
-        geocode_element.assert_not_called()
-        tasks.geocode_support_group(fake.uuid4())
-        geocode_element.assert_not_called()
-
     @patch(
         "agir.groups.tasks.geocode_element",
         side_effect=mock_geocode_element_no_position,

--- a/agir/municipales/tasks.py
+++ b/agir/municipales/tasks.py
@@ -2,18 +2,16 @@ from django.conf import settings
 from django.core.mail import EmailMessage
 from django.template.loader import get_template
 
-from agir.lib.celery import emailing_task
+from agir.lib.celery import emailing_task, post_save_task
 from agir.municipales.models import CommunePage
 from agir.people.models import Person
 
 
 @emailing_task
+@post_save_task
 def notify_commune_changed(commune_id, person_id, changed_data):
-    try:
-        commune = CommunePage.objects.get(id=commune_id)
-        nom_commune = f"{commune.name} ({commune.code_departement})"
-    except CommunePage.DoesNotExist:
-        return
+    commune = CommunePage.objects.get(id=commune_id)
+    nom_commune = f"{commune.name} ({commune.code_departement})"
 
     try:
         person = Person.objects.get(id=person_id)
@@ -35,12 +33,9 @@ def notify_commune_changed(commune_id, person_id, changed_data):
 
 
 @emailing_task
+@post_save_task
 def send_procuration_email(commune_id, nom_complet, email, phone, bureau, autres):
-    try:
-        commune = CommunePage.objects.get(id=commune_id)
-    except CommunePage.DoesNotExist:
-        return
-
+    commune = CommunePage.objects.get(id=commune_id)
     if commune.contact_email:
         personnel = False
         recipients = [commune.contact_email]

--- a/agir/people/tasks.py
+++ b/agir/people/tasks.py
@@ -11,7 +11,7 @@ from agir.authentication.tokens import (
     add_email_confirmation_token_generator,
     merge_account_token_generator,
 )
-from agir.lib.celery import emailing_task
+from agir.lib.celery import emailing_task, post_save_task
 from agir.lib.display import pretty_time_since
 from agir.lib.mailing import send_mosaico_email
 from agir.lib.sms import send_sms
@@ -125,11 +125,9 @@ def send_confirmation_merge_account(user_pk_requester, user_pk_merge, **kwargs):
 
 
 @emailing_task
+@post_save_task
 def send_confirmation_change_email(new_email, user_pk, **kwargs):
-    try:
-        Person.objects.get(pk=user_pk)
-    except Person.DoesNotExist:
-        return
+    Person.objects.get(pk=user_pk)
 
     subscription_token = add_email_confirmation_token_generator.make_token(
         new_email=new_email, user=user_pk
@@ -169,12 +167,9 @@ def send_unsubscribe_email(person_pk):
 
 
 @emailing_task
+@post_save_task
 def send_person_form_confirmation(submission_pk):
-    try:
-        submission = PersonFormSubmission.objects.get(pk=submission_pk)
-    except:
-        return
-
+    submission = PersonFormSubmission.objects.get(pk=submission_pk)
     person = submission.person
     form = submission.form
 
@@ -190,12 +185,9 @@ def send_person_form_confirmation(submission_pk):
 
 
 @emailing_task
+@post_save_task
 def send_person_form_notification(submission_pk):
-    try:
-        submission = PersonFormSubmission.objects.get(pk=submission_pk)
-    except:
-        return
-
+    submission = PersonFormSubmission.objects.get(pk=submission_pk)
     form = submission.form
 
     if form.send_answers_to is None:
@@ -231,12 +223,9 @@ def send_person_form_notification(submission_pk):
 
 
 @shared_task
+@post_save_task
 def send_validation_sms(sms_id):
-    try:
-        sms = PersonValidationSMS.objects.get(id=sms_id)
-    except PersonValidationSMS.DoesNotExist:
-        return
-
+    sms = PersonValidationSMS.objects.get(id=sms_id)
     formatted_code = sms.code[:3] + " " + sms.code[3:]
     message = f"Votre code de validation pour votre compte France insoumise est {formatted_code}"
 


### PR DESCRIPTION
Je ne l'ai pas ajouté lorsqu'il n'y avait pas de récupération de l'objet en argument en BDD dans la tâche, ni lorsque la logique me semblait trop spécifique.