### PR TITLE
Group settings fixes

### DIFF
--- a/agir/front/components/formComponents/ImageField.js
+++ b/agir/front/components/formComponents/ImageField.js
@@ -111,6 +111,7 @@ const ImageField = forwardRef((props, ref) => {
             name={name}
             type="file"
             onChange={handleChange}
+            value=""
           />
           <Button type="button" inline $wrap onClick={handleClick}>
             <RawFeatherIcon name="camera" style={{ marginRight: "0.5rem" }} />

--- a/agir/front/components/formComponents/ImageField.js
+++ b/agir/front/components/formComponents/ImageField.js
@@ -51,9 +51,9 @@ const ImageField = forwardRef((props, ref) => {
   const labelRef = useRef(null);
   const handleChange = useCallback(
     (e) => {
-      e?.target?.files &&
-        onChange &&
-        onChange(e.target.files[e.target.files.length - 1]);
+      const file =
+        e?.target?.files && e.target.files[e.target.files.length - 1];
+      file && onChange && onChange(file);
     },
     [onChange]
   );


### PR DESCRIPTION
- Fix image upload bug on Chrome - onChange event is not fired on type-file input upon selecting the same file multiple times
- Fix: image is deleted if user open the upload prompt and chooses no file
- Try to improve group membership retrieve endpoint