### PR TITLE
Sortons ce Spacer de là où il se cache !

### DIFF
--- a/agir/front/components/genericComponents/ObjectManagement/ManagementMenu.js
+++ b/agir/front/components/genericComponents/ObjectManagement/ManagementMenu.js
@@ -170,8 +170,8 @@ const ManagementMenu = (props) => {
     <StyledMenu>
       <Hide over>
         <BackButton onClick={onBack} />
-        <Spacer size="1rem" />
       </Hide>
+      <Spacer size="1rem" />
       <h6>{subtitle}</h6>
       <h4>{title}</h4>
       <Spacer size="1rem" />


### PR DESCRIPTION
Ajout d'un peu de marge sur le titre/sous-titre du menu de la gestion de groupe sur desktop

*Bonus* : aucun lien avec cette PR, mais [un lien](https://gist.github.com/claus/622a938d21d80f367251dc2eaaa1b2a9) qui pourra être utile à l'avenir.