### PR TITLE
Ce qui nous rappelle de ne pas toujours faire nos tests avec les droits d'admin

### DIFF
--- a/agir/groups/views/api_views.py
+++ b/agir/groups/views/api_views.py
@@ -525,10 +525,11 @@ class GroupMemberUpdateAPIView(UpdateAPIView):
     permission_classes = (GroupManagementPermission,)
     serializer_class = MembershipSerializer
 
-    def get_object(self):
-        membership = super(GroupMemberUpdateAPIView, self).get_object()
-        self.check_object_permissions(self.request, membership.supportgroup)
-        return membership
+    def check_object_permissions(self, request, obj):
+        # Object permission are for the membership's support group, not the object itself
+        return super(GroupMemberUpdateAPIView, self).check_object_permissions(
+            request, obj.supportgroup
+        )
 
 
 class GroupFinancePermission(GlobalOrObjectPermissions):


### PR DESCRIPTION
cf. https://erreurs.lafranceinsoumise.fr/organizations/onfi/issues/1057/?project=3&query=is%3Aunresolved

La methode `get_object` fait déjà un appel à `check_object_permissions`, ce qui causait une erreur parce qu'on vérifiait des permissions sur le SupportGroup avec une instance de Membership. Il suffit ici de surcharger juste `check_object_permissions`, parce que le reste de la methode `get_object` fait ce que l'on veut.