### PR TITLE
Un point c'est tout ?

### DIFF
--- a/agir/activity/serializers.py
+++ b/agir/activity/serializers.py
@@ -14,7 +14,21 @@ class ActivitySerializer(FlexibleFieldsMixin, serializers.ModelSerializer):
 
     timestamp = serializers.DateTimeField(read_only=True)
 
-    event = EventSerializer(fields=EventSerializer.EVENT_CARD_FIELDS, read_only=True,)
+    event = EventSerializer(
+        fields=[
+            "id",
+            "name",
+            "startTime",
+            "endTime",
+            "illustration",
+            "schedule",
+            "location",
+            "rsvp",
+            "routes",
+            "subtype",
+        ],
+        read_only=True,
+    )
     supportGroup = SupportGroupSerializer(
         source="supportgroup", fields=["id", "name", "url", "routes"], read_only=True
     )

--- a/agir/carte/models.py
+++ b/agir/carte/models.py
@@ -58,18 +58,17 @@ def download_static_map_image_from_jawg(
 class StaticMapImageManager(models.Manager):
     def create_from_jawg(self, *args, **kwargs):
         image = download_static_map_image_from_jawg(**kwargs)
-        static_map_image = super(StaticMapImageManager, self).create(
-            *args, **kwargs, image=image,
-        )
+        static_map_image = super().create(*args, **kwargs, image=image,)
         return static_map_image
 
     def create(self, *args, **kwargs):
         if kwargs.get("image", None) is None:
             return self.create_from_jawg(*args, **kwargs)
-        return super(StaticMapImageManager, self).create(*args, **kwargs)
+        return super().create(*args, **kwargs)
 
 
 class StaticMapImage(models.Model):
+    UNIQUE_CENTER_MAX_DISTANCE = 1
     DEFAULT_WIDTH = DEFAULT_MAP_WIDTH
     DEFAULT_HEIGHT = DEFAULT_MAP_HEIGHT
     DEFAULT_ZOOM = DEFAULT_MAP_ZOOM

--- a/agir/events/components/agendaPage/Agenda.js
+++ b/agir/events/components/agendaPage/Agenda.js
@@ -282,7 +282,6 @@ const Agenda = () => {
   const is2022 = useSelector(getIs2022);
   const isSessionLoaded = useSelector(getIsSessionLoaded);
   const user = useSelector(getUser);
-  const path = useLocation().pathname;
 
   const isPaused = useCallback(() => {
     return !user;

--- a/agir/events/serializers.py
+++ b/agir/events/serializers.py
@@ -84,28 +84,23 @@ class EventOptionsSerializer(serializers.Serializer):
         return obj.get_price_display()
 
 
-class EventListSerializer(serializers.ListSerializer):
-    def get_groups(self, obj):
-        return SupportGroupSerializer(
-            obj.organizers_groups.distinct(),
-            context=self.context,
-            many=True,
-            fields=["name", "isMember"],
-        ).data
-
-
 class EventSerializer(FlexibleFieldsMixin, serializers.Serializer):
     EVENT_CARD_FIELDS = [
         "id",
         "name",
+        "illustration",
+        "hasSubscriptionForm",
         "startTime",
         "endTime",
-        # "participantCount",
-        "illustration",
-        "schedule",
         "location",
+        "isOrganizer",
         "rsvp",
+        "hasRightSubscription",
+        "is2022",
         "routes",
+        "groups",
+        "distance",
+        "compteRendu",
         "subtype",
     ]
 
@@ -244,8 +239,15 @@ class EventSerializer(FlexibleFieldsMixin, serializers.Serializer):
             ],
         ).data
 
-    class Meta:
-        list_serializer_class = EventListSerializer
+
+class EventListSerializer(EventSerializer):
+    def get_groups(self, obj):
+        return SupportGroupSerializer(
+            obj.organizers_groups.distinct(),
+            context=self.context,
+            many=True,
+            fields=["name", "isMember"],
+        ).data
 
 
 class EventCreateOptionsSerializer(FlexibleFieldsMixin, serializers.Serializer):

--- a/agir/groups/views/api_views.py
+++ b/agir/groups/views/api_views.py
@@ -23,7 +23,7 @@ from rest_framework.response import Response
 from rest_framework import exceptions
 
 from agir.events.models import Event
-from agir.events.serializers import EventSerializer
+from agir.events.serializers import EventListSerializer
 from agir.groups.actions.notifications import (
     new_message_notifications,
     new_comment_notifications,
@@ -190,7 +190,7 @@ class NearGroupsAPIView(ListAPIView):
 
 class GroupEventsAPIView(ListAPIView):
     permission_ = ("groups.view_supportgroup",)
-    serializer_class = EventSerializer
+    serializer_class = EventListSerializer
     queryset = Event.objects.listed()
 
     def get_queryset(self):
@@ -198,12 +198,18 @@ class GroupEventsAPIView(ListAPIView):
             self.supportgroup.organized_events.listed()
             .distinct()
             .order_by("-start_time")
+            .select_related("subtype")
         )
         return events
 
-    def dispatch(self, request, pk, *args, **kwargs):
+    def get_serializer(self, *args, **kwargs):
+        return super().get_serializer(
+            *args, fields=EventListSerializer.EVENT_CARD_FIELDS, **kwargs,
+        )
+
+    def dispatch(self, request, *args, **kwargs):
         try:
-            self.supportgroup = SupportGroup.objects.get(pk=pk)
+            self.supportgroup = SupportGroup.objects.get(pk=kwargs.get("pk"))
         except SupportGroup.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
@@ -212,8 +218,13 @@ class GroupEventsAPIView(ListAPIView):
 
 class GroupUpcomingEventsAPIView(ListAPIView):
     permission_ = ("groups.view_supportgroup",)
-    serializer_class = EventSerializer
+    serializer_class = EventListSerializer
     queryset = Event.objects.listed().upcoming()
+
+    def get_serializer(self, *args, **kwargs):
+        return super().get_serializer(
+            *args, fields=EventListSerializer.EVENT_CARD_FIELDS, **kwargs,
+        )
 
     def get_queryset(self):
         events = (
@@ -221,12 +232,13 @@ class GroupUpcomingEventsAPIView(ListAPIView):
             .upcoming()
             .distinct()
             .order_by("start_time")
+            .select_related("subtype")
         )
         return events
 
-    def dispatch(self, request, pk, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):
         try:
-            self.supportgroup = SupportGroup.objects.get(pk=pk)
+            self.supportgroup = SupportGroup.objects.get(pk=kwargs.get("pk"))
         except SupportGroup.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
@@ -235,9 +247,14 @@ class GroupUpcomingEventsAPIView(ListAPIView):
 
 class GroupPastEventsAPIView(ListAPIView):
     permission_ = ("groups.view_supportgroup",)
-    serializer_class = EventSerializer
+    serializer_class = EventListSerializer
     queryset = Event.objects.listed().past()
     pagination_class = APIPaginator
+
+    def get_serializer(self, *args, **kwargs):
+        return super().get_serializer(
+            *args, fields=EventListSerializer.EVENT_CARD_FIELDS, **kwargs,
+        )
 
     def get_queryset(self):
         events = (
@@ -245,12 +262,13 @@ class GroupPastEventsAPIView(ListAPIView):
             .past()
             .distinct()
             .order_by("-start_time")
+            .select_related("subtype")
         )
         return events
 
-    def dispatch(self, request, pk, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):
         try:
-            self.supportgroup = SupportGroup.objects.get(pk=pk)
+            self.supportgroup = SupportGroup.objects.get(pk=kwargs.get("pk"))
         except SupportGroup.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
@@ -259,8 +277,13 @@ class GroupPastEventsAPIView(ListAPIView):
 
 class GroupPastEventReportsAPIView(ListAPIView):
     permission_ = ("groups.view_supportgroup",)
-    serializer_class = EventSerializer
+    serializer_class = EventListSerializer
     queryset = Event.objects.listed().past()
+
+    def get_serializer(self, *args, **kwargs):
+        return super().get_serializer(
+            *args, fields=EventListSerializer.EVENT_CARD_FIELDS, **kwargs,
+        )
 
     def get_queryset(self):
         events = (
@@ -269,12 +292,13 @@ class GroupPastEventReportsAPIView(ListAPIView):
             .exclude(report_content="")
             .distinct()
             .order_by("-start_time")
+            .select_related("subtype")
         )
         return events
 
-    def dispatch(self, request, pk, *args, **kwargs):
+    def dispatch(self, request, *args, **kwargs):
         try:
-            self.supportgroup = SupportGroup.objects.get(pk=pk)
+            self.supportgroup = SupportGroup.objects.get(pk=kwargs.get("pk"))
         except SupportGroup.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 

--- a/agir/lib/serializers.py
+++ b/agir/lib/serializers.py
@@ -82,11 +82,15 @@ class LocationSerializer(serializers.Serializer):
     def get_staticMapUrl(self, obj):
         if obj.coordinates is None:
             return ""
-        try:
-            static_map_image = StaticMapImage.objects.get(
-                center__distance_lt=(obj.coordinates, 1),
-            )
-        except StaticMapImage.DoesNotExist:
+
+        static_map_image = StaticMapImage.objects.filter(
+            center__distance_lt=(
+                obj.coordinates,
+                StaticMapImage.UNIQUE_CENTER_MAX_DISTANCE,
+            ),
+        ).first()
+
+        if static_map_image is None:
             create_static_map_image_from_coordinates.delay(
                 [obj.coordinates[0], obj.coordinates[1]]
             )


### PR DESCRIPTION
- Fix de la logique de récupération/création des images de carte statique qui causait une exception
- Amélioration des performances du serializer pour les listes d'événements et des views qui l'utilisent : il paraît que le ListSerializer de Rest Framework ne permet pas de surcharger les methodes de SerializerMethodField; on chargeait donc, sur tous les endpoints qui récupèrent des liste d'événements, pleins de données des groupes dont on avait pas besoin.