### PR TITLE
De même que le fleuve retourne à la mer, le don de l'homme revient vers lui

### DIFF
--- a/agir/donations/components/donationForm/AllocationsWidget/components.js
+++ b/agir/donations/components/donationForm/AllocationsWidget/components.js
@@ -48,6 +48,7 @@ export const GroupAllocation = ({
     <AmountBoxContainer>
       <AmountInput
         value={amount}
+        disabled={disabled}
         onChange={(v) => {
           if (v === null) {
             onChange(0);

--- a/agir/donations/components/donationForm/AllocationsWidget/index.js
+++ b/agir/donations/components/donationForm/AllocationsWidget/index.js
@@ -76,6 +76,7 @@ const AllocationsWidget = ({ groupChoices, value, onChange, maxAmount }) => {
         ))}
         {extra && (
           <GroupAllocation
+            disabled
             onRemove={() => {
               setExtra(false);
             }}


### PR DESCRIPTION
Fix de l'erreur [#ACTIONPOPULAIRE-FRONT-KP](https://erreurs.lafranceinsoumise.fr/organizations/onfi/issues/708/?project=4&query=is%3Aunresolved) qui causait un crash sur la page des dons lorsqu'on essayer de modifier le montant de l'allocation aux *activité nationales* sans avoir choisi de groupe bénéficiaire.