### PR TITLE
Une erreur qui ne dit pas son nom (fixes #ACTIONPOPULAIRE-FRONT-S0)

### DIFF
--- a/agir/front/components/app/utils.js
+++ b/agir/front/components/app/utils.js
@@ -13,7 +13,15 @@ export const lazy = (lazyImport, fallback) => {
             return await lazyImport();
           } catch (err) {
             if (err.name !== "ChunkLoadError") {
-              throw err;
+              if (err instanceof Error) {
+                throw err;
+              }
+              const message = err?.message
+                ? err.message
+                : typeof err === "string"
+                ? err
+                : "Lazy loading failed.";
+              throw new Error(message);
             }
             setError(err.toString());
             const Fallback = () =>

--- a/agir/front/components/globalContext/GlobalContext.js
+++ b/agir/front/components/globalContext/GlobalContext.js
@@ -39,9 +39,17 @@ const ProdProvider = ({ hasRouter = false, hasToasts = false, children }) => {
     if (!sessionContext) return;
 
     if (!sessionContext.user) {
-      self.caches?.delete("session").catch((e) => {
-        if (e.name !== "SecurityError") {
-          throw e;
+      self.caches?.delete("session").catch((err) => {
+        if (err.name !== "SecurityError") {
+          if (err instanceof Error) {
+            throw err;
+          }
+          const message = err?.message
+            ? err.message
+            : typeof err === "string"
+            ? err
+            : "Session cache deletion failed.";
+          throw new Error(message);
         }
       });
     }


### PR DESCRIPTION
Nous avons actuellement beaucoup d'erreurs dans Sentry ([ACTIONPOPULAIRE-FRONT-S0](https://erreurs.lafranceinsoumise.fr/organizations/onfi/issues/884/events/025f0c18b52f4b9bb867242ff9b1919d/)) dont le message est `UnhandledRejection: Non-Error promise rejection captured with value:`, ce qui ne donne pas beaucoup d'indications sur l'origine de l'erreur. 
Selon [cette page du site de Sentry](https://help.sentry.io/sdks/configuration/why-am-i-seeing-events-with-non-error-exception-or-promise-rejection-captured-with-keys-using-the-javascript-sdk/) cela est probablement dû à un appel de `throw` dans le code javascript avec un objet simple en paramètre, au lieu d'un `Error`.
Pour essayer d'avoir plus d'informations sur cette erreur, j'ai ajouté une condition aux deux seuls endroits où on appelle `throw`, pour s'assurer que ce qu'on `throw` est bien un `Error`.