### PR TITLE
Trois endpoints sont mieux qu'un seul ?

### DIFF
--- a/agir/activity/components/common/actions.js
+++ b/agir/activity/components/common/actions.js
@@ -62,11 +62,3 @@ export const undoRequiredActionActivityDismissal = async (id) => {
     console.log(e);
   }
 };
-
-export const setAnnouncementsAsRead = async (ids = []) => {
-  try {
-    await setActivitiesAsDisplayed(ids);
-  } catch (e) {
-    console.log(e);
-  }
-};

--- a/agir/activity/components/common/tests/actions.test.js
+++ b/agir/activity/components/common/tests/actions.test.js
@@ -2,7 +2,6 @@ import * as activityHelpers from "@agir/activity/common/helpers";
 import {
   dismissRequiredActionActivity,
   setAllActivitiesAsRead,
-  setAnnouncementsAsRead,
   undoRequiredActionActivityDismissal,
 } from "@agir/activity/common/actions";
 import { mutate } from "swr";
@@ -179,24 +178,6 @@ describe("activity/actions", function () {
       expect(activityHelpers.setActivityAsDisplayed.mock.calls).toHaveLength(1);
       expect(mutate.mock.calls).toHaveLength(1);
       expect(mutate.mock.calls[0][0]).toEqual("/api/user/required-activities/");
-    });
-  });
-  describe("setAnnouncementsAsRead action", function () {
-    afterEach(() => {
-      activityHelpers.setActivitiesAsDisplayed.mockClear();
-    });
-    it("should call activity helper function 'setActivitiesAsDisplayed'", function () {
-      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
-        0
-      );
-      const ids = [1, 2, 3];
-      setAnnouncementsAsRead(ids);
-      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls).toHaveLength(
-        1
-      );
-      expect(activityHelpers.setActivitiesAsDisplayed.mock.calls[0][0]).toEqual(
-        ids
-      );
     });
   });
 });

--- a/agir/activity/serializers.py
+++ b/agir/activity/serializers.py
@@ -62,25 +62,17 @@ class ActivitySerializer(FlexibleFieldsMixin, serializers.ModelSerializer):
 
 
 class AnnouncementSerializer(serializers.ModelSerializer):
-    activityId = serializers.SerializerMethodField()
-    customDisplay = serializers.SlugField(source="custom_display")
-
-    link = serializers.HyperlinkedIdentityField(view_name="activity:announcement_link")
-
-    startDate = serializers.DateTimeField(source="start_date")
-    endDate = serializers.DateTimeField(source="end_date")
-
-    image = serializers.SerializerMethodField()
-
-    def get_activityId(self, obj):
-        user = self.context["request"].user
-        if getattr(obj, "activity_id", None):
-            return obj.activity_id
-        if hasattr(user, "person"):
-            activity = Activity.objects.create(
-                type=Activity.TYPE_ANNOUNCEMENT, recipient=user.person, announcement=obj
-            )
-            return activity.id
+    # activityId = serializers.SerializerMethodField(read_only=True)
+    customDisplay = serializers.SlugField(source="custom_display", read_only=True)
+    link = serializers.HyperlinkedIdentityField(
+        view_name="activity:announcement_link", read_only=True
+    )
+    startDate = serializers.DateTimeField(source="start_date", read_only=True)
+    endDate = serializers.DateTimeField(source="end_date", read_only=True)
+    image = serializers.SerializerMethodField(read_only=True)
+    activityId = serializers.IntegerField(
+        source="activity_id", default=None, read_only=True
+    )
 
     def get_image(self, obj):
         if obj.image:

--- a/agir/activity/serializers.py
+++ b/agir/activity/serializers.py
@@ -62,7 +62,6 @@ class ActivitySerializer(FlexibleFieldsMixin, serializers.ModelSerializer):
 
 
 class AnnouncementSerializer(serializers.ModelSerializer):
-    # activityId = serializers.SerializerMethodField(read_only=True)
     customDisplay = serializers.SlugField(source="custom_display", read_only=True)
     link = serializers.HyperlinkedIdentityField(
         view_name="activity:announcement_link", read_only=True

--- a/agir/activity/urls.py
+++ b/agir/activity/urls.py
@@ -24,6 +24,16 @@ urlpatterns = [
         name="api_user_activities",
     ),
     path(
+        "api/announcements/",
+        views.AnnouncementsAPIView.as_view(),
+        name="api_user_announcements",
+    ),
+    path(
+        "api/user/announcements/custom/<str:custom_display>/",
+        views.UserCustomAnnouncementAPIView.as_view(),
+        name="api_user_custom_announcement",
+    ),
+    path(
         "activite/<uuid:pk>/lien/",
         views.AnnouncementLinkView.as_view(),
         name="announcement_link",

--- a/agir/authentication/serializers.py
+++ b/agir/authentication/serializers.py
@@ -41,21 +41,26 @@ class UserContextSerializer(serializers.Serializer):
 
 
 class SessionSerializer(serializers.Serializer):
-    csrfToken = serializers.SerializerMethodField(method_name="get_csrf_token")
-    user = serializers.SerializerMethodField(method_name="get_user")
-    toasts = serializers.SerializerMethodField(method_name="get_toasts")
-    announcements = serializers.SerializerMethodField(method_name="get_announcements")
-    routes = serializers.SerializerMethodField(method_name="get_user_routes")
-    facebookLogin = serializers.SerializerMethodField(method_name="get_facebook_login")
+    csrfToken = serializers.SerializerMethodField(
+        method_name="get_csrf_token", read_only=True
+    )
+    user = serializers.SerializerMethodField(method_name="get_user", read_only=True)
+    toasts = serializers.SerializerMethodField(method_name="get_toasts", read_only=True)
+    routes = serializers.SerializerMethodField(
+        method_name="get_user_routes", read_only=True
+    )
+    facebookLogin = serializers.SerializerMethodField(
+        method_name="get_facebook_login", read_only=True
+    )
     hasUnreadActivities = serializers.SerializerMethodField(
-        method_name="get_has_unread_activities"
+        method_name="get_has_unread_activities", read_only=True
     )
     requiredActionActivitiesCount = serializers.SerializerMethodField(
-        method_name="get_required_action_activities_count"
+        method_name="get_required_action_activities_count", read_only=True
     )
-    authentication = serializers.SerializerMethodField()
+    authentication = serializers.SerializerMethodField(read_only=True)
     bookmarkedEmails = serializers.SerializerMethodField(
-        method_name="get_bookmarked_emails"
+        method_name="get_bookmarked_emails", read_only=True
     )
 
     def get_authentication(self, request):
@@ -76,7 +81,7 @@ class SessionSerializer(serializers.Serializer):
             "nspReferral": front_url("nsp_referral"),
         }
 
-        if request.user.is_authenticated:
+        if request.user.is_authenticated and request.user.person is not None:
             person = request.user.person
             routes.update(
                 {
@@ -140,14 +145,6 @@ class SessionSerializer(serializers.Serializer):
         if request.user.is_authenticated and request.user.person is not None:
             return UserContextSerializer(instance=request.user.person).data
         return False
-
-    def get_announcements(self, request):
-        if request.user.is_authenticated and request.user.person is not None:
-            return AnnouncementSerializer(
-                many=True,
-                instance=get_announcements(request.user.person),
-                context={"request": request},
-            ).data
 
     def get_facebook_login(self, request):
         return (

--- a/agir/front/components/authentication/Connexion/TellMore/TellMorePage.js
+++ b/agir/front/components/authentication/Connexion/TellMore/TellMorePage.js
@@ -15,9 +15,11 @@ const TellMorePage = () => {
 
   const { available, isSubscribed, subscribe, ready, errorMessage } = usePush();
 
-  const [hasCampaign, dismissCampaign] =
+  const [hasCampaign, dismissCampaign, campaignIsLoading] =
     useCustomAnnouncement("chooseCampaign");
-  const [hasTellMore, dismissTellMore] = useCustomAnnouncement("tellMore");
+  const [hasTellMore, dismissTellMore, tellMoreIsLoading] =
+    useCustomAnnouncement("tellMore");
+
   const [
     hasDeviceNotificationSubscription,
     setHasDeviceNotificationSubscription,
@@ -44,6 +46,10 @@ const TellMorePage = () => {
 
   if (!isTellMorePage && (hasCampaign || hasTellMore)) {
     return <Redirect to={routeConfig.tellMore.getLink()} />;
+  }
+
+  if (campaignIsLoading || tellMoreIsLoading) {
+    return null;
   }
 
   if (hasCampaign) {

--- a/agir/front/components/dashboardComponents/Announcements.js
+++ b/agir/front/components/dashboardComponents/Announcements.js
@@ -10,7 +10,6 @@ import Announcement from "@agir/front/genericComponents/Announcement";
 import style from "@agir/front/genericComponents/_variables.scss";
 import "./Announcements.scss";
 import useSWR from "swr";
-import { setAnnouncementsAsRead } from "@agir/activity/common/actions";
 
 SwiperCore.use([Pagination, A11y]);
 
@@ -107,36 +106,7 @@ BannerAnnouncements.propTypes = SidebarAnnouncements.propTypes = {
 
 const Announcements = (props) => {
   const { displayType } = props;
-  const { data } = useSWR("/api/session/");
-  const readAnnouncementIds = useRef([]);
-
-  const announcements = useMemo(
-    () =>
-      Array.isArray(data?.announcements)
-        ? data.announcements.filter((a) => !a.customDisplay)
-        : [],
-    [data]
-  );
-
-  const announcementIds = useMemo(
-    () =>
-      announcements.map((announcement) => announcement.activityId).join(","),
-    [announcements]
-  );
-
-  useEffect(() => {
-    if (!announcementIds) {
-      return;
-    }
-    const ids = announcementIds
-      .split(",")
-      .filter(
-        (announcementId) =>
-          !readAnnouncementIds.current.includes(announcementId)
-      );
-    readAnnouncementIds.current = announcementIds.split(",");
-    setAnnouncementsAsRead(ids);
-  }, [announcementIds]);
+  const { data: announcements } = useSWR("/api/announcements/");
 
   if (!announcements) return null;
 


### PR DESCRIPTION
- create Announcement and UserCustomAnnouncement API views
- update useCustomAnnouncement hook to use the dedicated API endpoint
- update Announcements component to use the dedicated API endpoint
- remove field announcement from SessionSerializer to speed up `api/session` endpoint