### PR TITLE
Un standard pour la transmission des paquets IP sur pigeons voyageurs

### DIFF
--- a/agir/groups/components/groupPage/hooks/messages.js
+++ b/agir/groups/components/groupPage/hooks/messages.js
@@ -128,7 +128,7 @@ export const useMessage = (group, messagePk) => {
     [hasMessage, messagePk]
   );
 
-  const { data } = useSWR(getMessageEndpoint);
+  const { data } = useSWR(getMessageEndpoint, { refreshInterval: 1000 });
 
   useEffect(() => {
     !isLoading &&

--- a/agir/groups/tests/test_messages_api.py
+++ b/agir/groups/tests/test_messages_api.py
@@ -155,7 +155,7 @@ class GroupMessagesTestAPICase(APITestCase):
         self.assertEqual(res.data["text"], "Lorem")
         # self.assertEqual(res.data["image"], None)
         self.assertEqual(
-            res.data["group"], {"id": str(self.group.id), "name": self.group.name,}
+            res.data["group"], {"id": self.group.id, "name": self.group.name,}
         )
         self.assertIn("comments", res.data)
         self.assertNotIn("recentComments", res.data)

--- a/agir/groups/views/api_views.py
+++ b/agir/groups/views/api_views.py
@@ -340,6 +340,7 @@ class GroupMessagesAPIView(ListCreateAPIView):
         return (
             self.supportgroup.messages.filter(deleted=False)
             .select_related("author", "linked_event", "linked_event__subtype")
+            .prefetch_related("comments")
             .order_by("-created")
         )
 
@@ -357,7 +358,13 @@ class GroupMessagesAPIView(ListCreateAPIView):
 
 
 class GroupSingleMessageAPIView(RetrieveUpdateDestroyAPIView):
-    queryset = SupportGroupMessage.objects.filter(deleted=False)
+    queryset = (
+        SupportGroupMessage.objects.filter(deleted=False)
+        .select_related(
+            "supportgroup", "linked_event", "linked_event__subtype", "author"
+        )
+        .prefetch_related("comments")
+    )
     serializer_class = SupportGroupMessageSerializer
     permission_classes = (GlobalOrObjectPermissions,)
 


### PR DESCRIPTION
cf. [RFC1149](https://rfc1149.net/rfc1149.html)
- Ajout d'une option SWR à l'appel de l'api pour récuperer le détail d'un message de groupe (sur la page d'un seul message), pour que les données soient mises automatiquement à jour chaque seconde
- Simplification de la vue / serializer de l'endpoint pour réduire le nombre de requêtes en base de données