### PR TITLE
Rien n'est plus rare que ce qui est unique

### DIFF
--- a/agir/activity/views.py
+++ b/agir/activity/views.py
@@ -84,7 +84,11 @@ class UserCustomAnnouncementAPIView(RetrieveAPIView):
         return announcement
 
     def get_queryset(self):
-        return get_custom_announcements(self.request.user.person)
+        return (
+            get_custom_announcements(self.request.user.person)
+            .order_by("custom_display", "-priority", "-start_date", "end_date")
+            .distinct("custom_display")
+        )
 
 
 class AnnouncementLinkView(DetailView):


### PR DESCRIPTION
Correction d'une erreur sur l'endpoint pour récupérer une annonce custom lorsque plusieurs annonces existent avec la même valeur pour la propriété `custom_display`