### PR TITLE
Trouver une fois, c'est trouver pour toujours

### DIFF
--- a/agir/activity/actions.py
+++ b/agir/activity/actions.py
@@ -66,31 +66,18 @@ def get_announcements(person=None):
     )
 
     if person:
-        announcements = (
-            announcements.filter(
-                pk__in=[
-                    a.pk
-                    for a in announcements
-                    if a.segment is None
-                    or a.segment.get_subscribers_queryset()
-                    .filter(pk=person.id)
-                    .exists()
-                ]
-            )
-            .exclude(
-                Q(
-                    activity__in=Activity.objects.filter(
-                        recipient=person, status=Activity.STATUS_INTERACTED
-                    )
-                ),
-                ~Q(custom_display__exact=""),
-            )
-            .annotate(
-                activity_id=Subquery(
-                    Activity.objects.filter(
-                        recipient=person, announcement_id=OuterRef("id")
-                    ).values("id")[:1]
-                )
+        announcements = announcements.filter(
+            pk__in=[
+                a.pk
+                for a in announcements
+                if a.segment is None
+                or a.segment.get_subscribers_queryset().filter(pk=person.id).exists()
+            ]
+        ).annotate(
+            activity_id=Subquery(
+                Activity.objects.filter(
+                    recipient=person, announcement_id=OuterRef("id")
+                ).values("id")[:1]
             )
         )
         # Automatically create an activity for the person if none exists for the announcement

--- a/agir/activity/components/common/hooks.js
+++ b/agir/activity/components/common/hooks.js
@@ -1,5 +1,6 @@
 import useSWR from "swr";
 import {
+  activityStatus,
   getUninteracted,
   getUnread,
   setActivityAsInteracted,
@@ -42,7 +43,15 @@ export const useCustomAnnouncement = (slug) => {
 
   const announcementId = data?.id;
   const announcement = useMemo(
-    () => (announcementId ? data : null),
+    () => {
+      if (
+        !announcementId ||
+        data?.status === activityStatus.STATUS_INTERACTED
+      ) {
+        return null;
+      }
+      return data;
+    },
     //eslint-disable-next-line
     [announcementId]
   );
@@ -54,7 +63,13 @@ export const useCustomAnnouncement = (slug) => {
     }
     await setActivityAsInteracted(activityId);
 
-    mutate(null, false);
+    mutate(
+      (announcement) => ({
+        ...announcement,
+        status: activityStatus.STATUS_INTERACTED,
+      }),
+      false
+    );
   }, [activityId, mutate]);
 
   return [announcement, dismissCallback, typeof data === "undefined"];

--- a/agir/activity/serializers.py
+++ b/agir/activity/serializers.py
@@ -94,6 +94,23 @@ class AnnouncementSerializer(serializers.ModelSerializer):
         ]
 
 
+class CustomAnnouncementSerializer(AnnouncementSerializer):
+    status = serializers.SerializerMethodField(read_only=True)
+
+    def get_status(self, obj):
+        if obj.activity_id is None:
+            return None
+        try:
+            activity = Activity.objects.get(pk=obj.activity_id)
+        except Activity.DoesNotExist:
+            return None
+        return activity.status
+
+    class Meta:
+        model = Announcement
+        fields = [*AnnouncementSerializer.Meta.fields, "status"]
+
+
 class ActivityStatusUpdateRequest(serializers.Serializer):
     status = serializers.ChoiceField(
         choices=[Activity.STATUS_DISPLAYED, Activity.STATUS_INTERACTED]

--- a/agir/activity/tests.py
+++ b/agir/activity/tests.py
@@ -359,4 +359,5 @@ class UserCustomAnnouncementAPITestCase(TestCase):
         response = self.client.get(
             f"/api/user/announcements/custom/{self.custom_announcement.custom_display}/"
         )
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], str(self.custom_announcement.id))

--- a/agir/activity/views.py
+++ b/agir/activity/views.py
@@ -21,6 +21,7 @@ from agir.activity.serializers import (
     ActivitySerializer,
     ActivityStatusUpdateRequest,
     AnnouncementSerializer,
+    CustomAnnouncementSerializer,
 )
 from agir.lib.rest_framework_permissions import (
     GlobalOrObjectPermissions,
@@ -72,7 +73,7 @@ class AnnouncementsAPIView(ListAPIView):
 
 class UserCustomAnnouncementAPIView(RetrieveAPIView):
     permission_classes = (IsAuthenticated,)
-    serializer_class = AnnouncementSerializer
+    serializer_class = CustomAnnouncementSerializer
     lookup_field = "custom_display"
 
     def get_object(self):


### PR DESCRIPTION
Éviter de renvoyer une réponse 404 Not Found sur l'endpoint `api/user/announcements/custom/<str:custom_display>/` lorsqu'une activité existe pour l'annonce mais son statut est `INTERACTED` :
- création d'un `CustomAnnouncementSerializer` qui hérite de `AnnouncementSerializer` et ajoute la propriété `status` égale au statut de l'activité correspondante (si celle-ci existe)
- Utilisation du nouveau serializer dans la vue `UserCustomAnnouncementAPIView`
- Suppression, dans l'action `get_announcements` de la condition qui excluait les annonces custom dont l'activité était au statut `INTERACTED`
- Mise à jour du hook React custom `useCustomAnnouncement` pour utiliser le nouveau format de réponse API