### PR TITLE
Aller en prison sans passer par la case départ

### DIFF
--- a/agir/front/components/authentication/Connexion/Signup.js
+++ b/agir/front/components/authentication/Connexion/Signup.js
@@ -112,7 +112,7 @@ const SignUp = () => {
         });
         return;
       }
-      const data = await signUp(formData);
+      const data = await signUp(formData, location?.state?.next);
       if (data.error) {
         setError(data.error);
         return;

--- a/agir/front/components/authentication/api.js
+++ b/agir/front/components/authentication/api.js
@@ -61,7 +61,7 @@ export const logout = async () => {
   return result;
 };
 
-export const signUp = async (data) => {
+export const signUp = async (data, next) => {
   const result = {
     data: null,
     error: null,
@@ -70,6 +70,7 @@ export const signUp = async (data) => {
     email: data.email.trim(),
     location_zip: data.postalCode,
     location_country: data.country,
+    next: next || undefined,
   };
   const url = ENDPOINT.signUp;
   try {

--- a/agir/lib/utils.py
+++ b/agir/lib/utils.py
@@ -1,4 +1,4 @@
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import requests
 from PIL import Image
@@ -120,3 +120,7 @@ def get_client_ip(request):
             return x_forwarded_for.split(",")[0].strip()
 
     return request.META["REMOTE_ADDR"]
+
+
+def is_absolute_url(url):
+    return isinstance(url, str) and url != "" and bool(urlparse(url).netloc)

--- a/agir/people/actions/subscription.py
+++ b/agir/people/actions/subscription.py
@@ -146,6 +146,8 @@ def save_subscription_information(person, type, data, new=False):
 
 def subscription_success_redirect_url(type, id, data):
     params = {"agir_id": str(id)}
-    params.update({f"agir_{k}": v for k, v in data.items()})
     url = SUBSCRIPTION_SUCCESS_REDIRECT[type]
+    if data.get("next", None):
+        url = data.pop("next")
+    params.update({f"agir_{k}": v for k, v in data.items()})
     return add_query_params_to_url(url, params, as_fragment=True)

--- a/agir/people/serializers.py
+++ b/agir/people/serializers.py
@@ -8,6 +8,7 @@ from rest_framework.validators import UniqueValidator
 from agir.elus.models import MandatMunicipal, StatutMandat, types_elus
 from agir.lib.data import french_zipcode_to_country_code, FRANCE_COUNTRY_CODES
 from agir.lib.serializers import FlexibleFieldsMixin
+from agir.lib.utils import is_absolute_url
 from . import models
 from .actions.subscription import (
     SUBSCRIPTION_TYPE_LFI,
@@ -76,6 +77,7 @@ class SubscriptionRequestSerializer(serializers.Serializer):
         choices=("municipal", "maire", "departemental", "regional", "consulaire"),
         required=False,
     )
+    next = serializers.CharField(required=False, allow_blank=True, write_only=True)
 
     referrer = serializers.CharField(required=False)
 
@@ -90,6 +92,11 @@ class SubscriptionRequestSerializer(serializers.Serializer):
 
     def validate_contact_phone(self, value):
         return value and str(value)
+
+    def validate_next(self, value):
+        if not value or is_absolute_url(value):
+            return ""
+        return value
 
     def validate(self, data):
         if (

--- a/agir/people/views/subscription.py
+++ b/agir/people/views/subscription.py
@@ -72,6 +72,7 @@ class ConfirmSubscriptionView(View):
         "mandat",
         "android",
         "ios",
+        "next",
     ]
     show_already_created_message = True
     default_type = SUBSCRIPTION_TYPE_LFI


### PR DESCRIPTION
Envoi d'un paramètre optionnel `next` dans le payload de la requête `POST api/inscription/` pour spécifier vers quelle URL rediriger l'utilisateur une fois l'inscription confirmée via le lien envoyé par email.

**Question** : en l'état, cela fonctionne avec n'importe quelle URL de redirection, je ne sais pas si cela peut poser des problèmes de sécurité et s'il y a une manière de valider la valeur envoyée.