### PR TITLE
difficile de trouver ce que l'on cherche dans les administrations

### DIFF
--- a/agir/api/admin_views.py
+++ b/agir/api/admin_views.py
@@ -2,6 +2,8 @@ from django.http.response import HttpResponse
 
 
 def page_not_found_view(request, exception):
-    response = HttpResponse("<!DOCTYPE html><html><body><h1>Page non trouvée</h1></body></html>")
+    response = HttpResponse(
+        "<!DOCTYPE html><html><body><h1>Page non trouvée</h1></body></html>"
+    )
     response.status_code = 404
     return response

--- a/agir/api/admin_views.py
+++ b/agir/api/admin_views.py
@@ -1,0 +1,7 @@
+from django.http.response import HttpResponse
+
+
+def page_not_found_view(request, exception):
+    response = HttpResponse("<!DOCTYPE html><html><body><h1>Page non trouvée</h1></body></html>")
+    response.status_code = 404
+    return response

--- a/agir/api/urls.py
+++ b/agir/api/urls.py
@@ -23,6 +23,9 @@ from . import settings
 
 handler404 = NotFoundView.as_view()
 
+if not settings.ENABLE_FRONT:
+    handler404 = "agir.api.admin_views.page_not_found_view"
+
 urlpatterns = [
     path("nuntius/", include("nuntius.urls")),
     path("webhooks/", include("agir.webhooks.urls")),
@@ -36,7 +39,6 @@ urlpatterns = [
 ]
 
 if settings.ENABLE_ADMIN:
-    handler404 = 'agir.api.admin_views.page_not_found_view'
     urlpatterns.append(path("", include("agir.api.admin_urls")))
 
 if settings.ENABLE_API:

--- a/agir/api/urls.py
+++ b/agir/api/urls.py
@@ -19,8 +19,6 @@ from django_prometheus.exports import ExportToDjangoView as metric_view
 
 from agir.lib.http import with_http_basic_auth
 from . import settings
-
-from django.conf.urls import handler404
 from agir.front.views import NotFoundView
 
 handler404 = NotFoundView.as_view()

--- a/agir/api/urls.py
+++ b/agir/api/urls.py
@@ -17,9 +17,11 @@ from django.conf.urls.static import static
 from django.urls import path, include
 from django_prometheus.exports import ExportToDjangoView as metric_view
 
-from agir.front.views import NotFoundView
 from agir.lib.http import with_http_basic_auth
 from . import settings
+
+from django.conf.urls import handler404
+from agir.front.views import NotFoundView
 
 handler404 = NotFoundView.as_view()
 

--- a/agir/api/urls.py
+++ b/agir/api/urls.py
@@ -17,11 +17,9 @@ from django.conf.urls.static import static
 from django.urls import path, include
 from django_prometheus.exports import ExportToDjangoView as metric_view
 
+from agir.front.views import NotFoundView
 from agir.lib.http import with_http_basic_auth
 from . import settings
-
-from django.conf.urls import handler404
-from agir.front.views import NotFoundView
 
 handler404 = NotFoundView.as_view()
 
@@ -38,6 +36,7 @@ urlpatterns = [
 ]
 
 if settings.ENABLE_ADMIN:
+    handler404 = 'agir.api.admin_views.page_not_found_view'
     urlpatterns.append(path("", include("agir.api.admin_urls")))
 
 if settings.ENABLE_API:


### PR DESCRIPTION
Création d'une 404 spécialement pour l'administration pour bien la séparer du site.
Pour l'instant la 404 est une simple chaine de caractères.