### PR TITLE
Sauvegarder son prochain comme soi-même

### DIFF
--- a/agir/front/components/app/Router.js
+++ b/agir/front/components/app/Router.js
@@ -39,7 +39,10 @@ export const ProtectedComponent = ({ Component, route, ...rest }) => {
 
   return (
     <Redirect
-      to={{ pathname: routeConfig.login.getLink(), state: { from: location } }}
+      to={{
+        pathname: routeConfig.login.getLink(),
+        state: { next: location.pathname },
+      }}
     />
   );
 };

--- a/agir/front/components/authentication/Connexion/Login.js
+++ b/agir/front/components/authentication/Connexion/Login.js
@@ -57,10 +57,12 @@ const ToastNotConnected = () => {
 const Login = () => {
   const history = useHistory();
   const location = useLocation();
+
+  const { isMobileApp } = useMobileApp();
   const [bookmarkedEmails] = useBookmarkedEmails();
+
   const [showMore, setShowMore] = useState(false);
   const [error, setError] = useState(null);
-  const { isMobileApp } = useMobileApp();
 
   const next = useMemo(() => {
     if (location.state?.next) {
@@ -74,7 +76,7 @@ const Login = () => {
     setShowMore(true);
   }, []);
 
-  const loginBookmarkedMail = useCallback(
+  const handleSubmit = useCallback(
     async (email) => {
       setError(null);
       const result = await login(email);
@@ -113,14 +115,14 @@ const Login = () => {
       {bookmarkedEmails.length > 0 && (
         <>
           <div style={{ marginTop: "1.5rem" }}>
-            {bookmarkedEmails.map((mail, id) => (
+            {bookmarkedEmails.map((email, id) => (
               <LoginMailButton
                 key={id}
                 color="primary"
-                onClick={() => loginBookmarkedMail(mail)}
+                onClick={() => handleSubmit(email)}
                 block
               >
-                <span>{mail}</span>
+                <span>{email}</span>
                 <img src={arrowRight} style={{ color: "white" }} />
               </LoginMailButton>
             ))}
@@ -167,14 +169,14 @@ const Login = () => {
               </InlineBlock>
             </ShowMore>
           ) : (
-            <LoginMailEmpty />
+            <LoginMailEmpty onSubmit={handleSubmit} error={error} />
           )}
         </>
       )}
 
       {bookmarkedEmails.length === 0 && (
         <>
-          <LoginMailEmpty />
+          <LoginMailEmpty onSubmit={handleSubmit} error={error} />
           {!isMobileApp && (
             <>
               <div

--- a/agir/front/components/authentication/Connexion/LoginMailEmpty.js
+++ b/agir/front/components/authentication/Connexion/LoginMailEmpty.js
@@ -1,10 +1,8 @@
+import PropTypes from "prop-types";
 import React, { useState, useCallback } from "react";
 import Button from "@agir/front/genericComponents/Button";
 import TextField from "@agir/front/formComponents/TextField";
 import Link from "@agir/front/app/Link";
-import { login } from "@agir/front/authentication/api";
-import { routeConfig } from "@agir/front/app/routes.config";
-import { useHistory, useLocation } from "react-router-dom";
 import style from "@agir/front/genericComponents/_variables.scss";
 import styled from "styled-components";
 
@@ -44,38 +42,17 @@ const Form = styled.form`
   }
 `;
 
-const LoginMailEmpty = () => {
-  const history = useHistory();
-  const location = useLocation();
+const LoginMailEmpty = ({ onSubmit, error }) => {
   const [email, setEmail] = useState("");
-  const [error, setError] = useState({});
-
-  let next = "";
-  if (location.search !== undefined)
-    next = new URLSearchParams(location.search).get("next");
 
   const handleInputChange = useCallback((e) => {
     setEmail(e.target.value);
   }, []);
 
-  const handleSubmit = useCallback(
-    async (e) => {
-      e.preventDefault();
-      setError({});
-      const result = await login(email);
-      if (result.error) {
-        setError(result.error);
-        return;
-      }
-      const route = routeConfig.codeLogin.getLink();
-      history.push(route, {
-        email: email,
-        code: result.data && result.data.code,
-        next: next,
-      });
-    },
-    [history, email, next]
-  );
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(email);
+  };
 
   return (
     <Form onSubmit={handleSubmit}>
@@ -83,7 +60,7 @@ const LoginMailEmpty = () => {
         <TextField
           id="email"
           label="Adresse e-mail"
-          error={error && (error.email || error.detail)}
+          error={error?.email || error?.detail}
           placeholder="Adresse e-mail"
           onChange={handleInputChange}
           value={email}
@@ -91,7 +68,7 @@ const LoginMailEmpty = () => {
           autoComplete="email"
           type="email"
         />
-        {!!error.detail && (
+        {error?.detail && (
           <Link route="codeLogin">
             Accéder à la page pour demander son code
           </Link>
@@ -106,4 +83,11 @@ const LoginMailEmpty = () => {
   );
 };
 
+LoginMailEmpty.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  error: PropTypes.shape({
+    email: PropTypes.string,
+    detail: PropTypes.string,
+  }),
+};
 export default LoginMailEmpty;

--- a/agir/groups/components/groupPage/GroupSettings/index.js
+++ b/agir/groups/components/groupPage/GroupSettings/index.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import React, { useMemo } from "react";
+import { useLocation } from "react-router-dom";
 
 import { routeConfig as globalRouteConfig } from "@agir/front/app/routes.config";
 import { getMenuRoute, getRoutes } from "./routes.config";
@@ -15,6 +16,8 @@ export const GroupSettings = (props) => {
   const routes = useMemo(() => getRoutes(basePath, group), [basePath, group]);
   const menuRoute = useMemo(() => getMenuRoute(basePath), [basePath]);
   const isAuthorized = useAuthentication(globalRouteConfig.groupSettings);
+  const { pathname } = useLocation();
+
   const redirectTo = useMemo(() => {
     if (!group?.isManager) {
       return basePath;
@@ -22,11 +25,11 @@ export const GroupSettings = (props) => {
     if (isAuthorized === false) {
       return {
         pathname: globalRouteConfig.login.getLink(),
-        state: { from: { pathname: menuRoute.getLink() } },
+        state: { next: pathname },
       };
     }
     return null;
-  }, [group, isAuthorized, basePath, menuRoute]);
+  }, [group, isAuthorized, basePath, pathname]);
 
   const subtitle = useMemo(
     () =>

--- a/agir/people/models.py
+++ b/agir/people/models.py
@@ -1,6 +1,8 @@
 import secrets
 import warnings
 from datetime import datetime
+
+from django.utils.safestring import mark_safe
 from dynamic_filenames import FilePattern
 from functools import reduce
 from operator import or_
@@ -614,7 +616,7 @@ class Person(
 
         return {
             **data,
-            "login_query": urlencode(generate_token_params(self)),
+            "login_query": mark_safe(urlencode(generate_token_params(self))),
             "greeting": self.formule_adresse,
             "full_name": self.get_full_name(),
             "short_name": self.get_short_name(),


### PR DESCRIPTION
- Éviter de remplacer le caractère `&` du paramètre `login_query` dans les templates email  avec le caractère HTML `&amp;` (ce qui casse la connexion automatique)
- Fix de la redirection vers la page originale après une connexion forcée