### PR TITLE
On ne se baigne jamais deux fois dans le même fleuve

### DIFF
--- a/agir/activity/actions.py
+++ b/agir/activity/actions.py
@@ -112,5 +112,35 @@ def get_non_custom_announcements(person=None):
     return get_announcements(person).filter(custom_display__exact="")
 
 
-def get_custom_announcements(person=None):
-    return get_announcements(person).exclude(custom_display__exact="")
+def get_custom_announcements(person, custom_display):
+    # Avoid calling get_announcement if an activity already exists for
+    # the person and the announcement
+    if person and custom_display:
+        today = timezone.now()
+        activity = (
+            Activity.objects.filter(
+                type=Activity.TYPE_ANNOUNCEMENT,
+                recipient=person,
+                announcement__custom_display__exact=custom_display,
+            )
+            .filter(
+                Q(announcement__start_date__lt=today)
+                & (
+                    Q(announcement__end_date__isnull=True)
+                    | Q(announcement__end_date__gt=today)
+                )
+            )
+            .only("id", "announcement_id")
+            .first()
+        )
+        if activity:
+            return Announcement.objects.filter(pk=activity.announcement_id,).annotate(
+                activity_id=Value(activity.id, IntegerField())
+            )
+
+    return (
+        get_announcements(person)
+        .exclude(custom_display__exact="")
+        .order_by("custom_display", "-priority", "-start_date", "end_date")
+        .distinct("custom_display")
+    )

--- a/agir/activity/views.py
+++ b/agir/activity/views.py
@@ -79,10 +79,8 @@ class UserCustomAnnouncementAPIView(RetrieveAPIView):
         return announcement
 
     def get_queryset(self):
-        return (
-            get_custom_announcements(self.request.user.person)
-            .order_by("custom_display", "-priority", "-start_date", "end_date")
-            .distinct("custom_display")
+        return get_custom_announcements(
+            self.request.user.person, self.kwargs.get(self.lookup_field, None)
         )
 
 


### PR DESCRIPTION
Les temps de réponse de l'endpoint API `/api/user/announcements/custom/{custom_display}/` sont impactés par le fait qu'à chaque requête on vérifie si la personne fait partie du segment de l'annonce et si un activité n'existe pas pour l'annonce / utilisateur, on la crée en base de données (en réalité, on ne se limite pas uniquement à l'annonce en question, mais on crée aussi si besoin toutes les activités d'annonces dont la personne est destinataire).

Toutes ces requêtes sont à priori nécessaires uniquement la première fois qu'une personne essaie de récupérer une annonce custom et peuvent être évitées si une activité pour l'annonce sélectionnée existe déjà. On passe ainsi de 15 à 4 requêtes en base de donnés.