### PR TITLE
Page `Messages` : retours - Le retour

### DIFF
--- a/agir/front/components/genericComponents/Avatar.js
+++ b/agir/front/components/genericComponents/Avatar.js
@@ -27,7 +27,7 @@ const getAvatarImageURL = (name, image) => {
 };
 const Avatar = styled.span.attrs(({ name, displayName, image }) => ({
   image: getAvatarImageURL(name || displayName, image),
-  title: name,
+  title: name || displayName,
 }))`
   border-radius: 100%;
   background-repeat: no-repeat;

--- a/agir/front/components/genericComponents/Avatars.js
+++ b/agir/front/components/genericComponents/Avatars.js
@@ -1,0 +1,65 @@
+import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
+
+import Avatar from "./Avatar";
+
+const StyledWrapper = styled.span`
+  display: inline-block;
+  padding: 0;
+  margin: 0;
+  line-height: 0;
+  display: grid;
+  grid-template-columns: 20px 20px 20px;
+  grid-template-rows: 20px 20px 20px;
+  isolation: isolate;
+
+  ${Avatar} {
+    width: 40px;
+    height: 40px;
+
+    :first-child {
+      grid-column: 1/3;
+      grid-row: 1/3;
+      width: 43px;
+      height: 43px;
+      border: 3px solid white;
+      z-index: 1;
+    }
+
+    :last-child {
+      grid-column: 2/4;
+      grid-row: 2/4;
+    }
+  }
+`;
+
+const Avatars = (props) => {
+  const { people, ...rest } = props;
+
+  if (!Array.isArray(people) || people.length < 2) {
+    return null;
+  }
+
+  return (
+    <StyledWrapper {...rest}>
+      {people.slice(0, 2).map((person, i) => (
+        <Avatar
+          key={person.id || i}
+          displayName={person.displayName}
+          image={person.image}
+        />
+      ))}
+    </StyledWrapper>
+  );
+};
+Avatars.propTypes = {
+  people: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      displayName: PropTypes.string.isRequired,
+      image: PropTypes.string,
+    }).isRequired
+  ).isRequired,
+};
+export default Avatars;

--- a/agir/front/components/genericComponents/Avatars.js
+++ b/agir/front/components/genericComponents/Avatars.js
@@ -17,13 +17,11 @@ const StyledWrapper = styled.span`
   ${Avatar} {
     width: 40px;
     height: 40px;
+    border: 3px solid white;
 
     :first-child {
       grid-column: 1/3;
       grid-row: 1/3;
-      width: 43px;
-      height: 43px;
-      border: 3px solid white;
       z-index: 1;
     }
 
@@ -37,15 +35,25 @@ const StyledWrapper = styled.span`
 const Avatars = (props) => {
   const { people, ...rest } = props;
 
-  if (!Array.isArray(people) || people.length < 2) {
+  if (!Array.isArray(people) || people.length === 0) {
     return null;
+  }
+
+  if (people.length === 1) {
+    return (
+      <Avatar
+        {...rest}
+        displayName={people[0].displayName}
+        image={people[0].image}
+      />
+    );
   }
 
   return (
     <StyledWrapper {...rest}>
       {people.slice(0, 2).map((person, i) => (
         <Avatar
-          key={person.id || i}
+          key={person.id + i}
           displayName={person.displayName}
           image={person.image}
         />

--- a/agir/front/components/genericComponents/Avatars.stories.js
+++ b/agir/front/components/genericComponents/Avatars.stories.js
@@ -1,0 +1,42 @@
+import React from "react";
+
+import Avatars from "./Avatars";
+
+export default {
+  component: Avatars,
+  title: "Generic/Avatars",
+  parameters: {
+    layout: "centered",
+  },
+};
+
+const Template = (args) => {
+  return (
+    <div
+      style={{
+        display: "inline-block",
+        height: "auto",
+        lineHeight: 0,
+        padding: 0,
+      }}
+    >
+      <Avatars {...args} />
+    </div>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  people: [
+    {
+      id: "abc",
+      displayName: "Jane Doe",
+      image: `https://www.fillmurray.com/160/160/`,
+    },
+    {
+      id: "cba",
+      displayName: "John Doe",
+      image: `https://www.fillmurray.com/161/161/`,
+    },
+  ],
+};

--- a/agir/front/components/mockData/messages.json
+++ b/agir/front/components/mockData/messages.json
@@ -7,7 +7,10 @@
       "displayName": "Bill Murray",
       "image": "https://www.fillmurray.com/200/200"
     },
+    "created": "2021-01-09 12:30:00",
+    "lastUpdate": "2021-01-09 12:30:00",
     "group": {
+      "id": "432a5071-3b8c-4bbc-9501-a3f9fd48f701",
       "name": "Comités d'appui et de travail pour une Vienne Insoumise"
     },
     "text": "Bonjour à tous les nouveaux membres ! Pour que tout le monde puisse vous connaître, je vous propose qu’on se rejoigne ensemble sur Zoom vendredi vers 20h.\n\nEst-ce que l’horaire convient à tout le monde ?",
@@ -33,6 +36,16 @@
           "name": "Groupe d'action 1"
         }
       ]
+    },
+    "lastComment": {
+      "id": "comment-1",
+      "author": {
+        "id": "Bill",
+        "displayName": "Bill Murray",
+        "image": "https://www.fillmurray.com/200/200"
+      },
+      "text": "Est-ce que c’est possible de commencer un peu plus tard ? Ma fille termine le karaté et j’arriverai à la maison tout juste...",
+      "created": "2021-01-09 12:30:00"
     },
     "recentComments": [
       {
@@ -85,7 +98,10 @@
       "id": "Isabelle",
       "displayName": "Isabelle Guérini"
     },
+    "created": "2021-01-09 12:30:00",
+    "lastUpdate": "2021-01-09 12:30:00",
     "group": {
+      "id": "432a5071-3b8c-4bbc-9501-a3f9fd48f702",
       "name": "Comités d'appui et de travail pour une Vienne Insoumise"
     },
     "text": "Bonjour à tous les nouveaux membres ! Pour que tout le monde puisse vous connaître, je vous propose qu’on se rejoigne ensemble sur Zoom vendredi vers 20h.\n\nEst-ce que l’horaire convient à tout le monde ?",
@@ -102,7 +118,10 @@
       "displayName": "Bill Murray",
       "image": "https://www.fillmurray.com/200/200"
     },
+    "created": "2021-01-09 12:30:00",
+    "lastUpdate": "2021-01-09 12:30:00",
     "group": {
+      "id": "432a5071-3b8c-4bbc-9501-a3f9fd48f703",
       "name": "Comités d'appui et de travail pour une Vienne Insoumise"
     },
     "text": "Bonjour à tous les nouveaux membres ! Pour que tout le monde puisse vous connaître, je vous propose qu’on se rejoigne ensemble sur Zoom vendredi vers 20h.\n\nEst-ce que l’horaire convient à tout le monde ?",
@@ -157,7 +176,10 @@
       "id": "Isabelle",
       "displayName": "Isabelle Guérini"
     },
+    "created": "2021-01-09 12:30:00",
+    "lastUpdate": "2021-01-09 12:30:00",
     "group": {
+      "id": "432a5071-3b8c-4bbc-9501-a3f9fd48f704",
       "name": "Comités d'appui et de travail pour une Vienne Insoumise"
     },
     "text": "Bonjour à tous les nouveaux membres ! Pour que tout le monde puisse vous connaître, je vous propose qu’on se rejoigne ensemble sur Zoom vendredi vers 20h.\n\nEst-ce que l’horaire convient à tout le monde ?",
@@ -173,7 +195,10 @@
       "id": "Isabelle",
       "displayName": "Isabelle Guérini"
     },
+    "created": "2021-01-09 12:30:00",
+    "lastUpdate": "2021-01-09 12:30:00",
     "group": {
+      "id": "432a5071-3b8c-4bbc-9501-a3f9fd48f705",
       "name": "Comités d'appui et de travail pour une Vienne Insoumise"
     },
     "text": "Bonjour à tous les nouveaux membres ! Pour que tout le monde puisse vous connaître, je vous propose qu’on se rejoigne ensemble sur Zoom vendredi vers 20h.\n\nEst-ce que l’horaire convient à tout le monde ?",

--- a/agir/groups/views/api_views.py
+++ b/agir/groups/views/api_views.py
@@ -1,7 +1,8 @@
 import reversion
 from django.contrib.gis.db.models.functions import Distance
 from django.db import transaction
-from django.db.models import F
+from django.db.models import F, Max, DateTimeField
+from django.db.models.functions import Greatest
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from django_filters.rest_framework import DjangoFilterBackend
@@ -369,6 +370,11 @@ class GroupSingleMessageAPIView(RetrieveUpdateDestroyAPIView):
             "supportgroup", "linked_event", "linked_event__subtype", "author"
         )
         .prefetch_related("comments")
+        .annotate(
+            last_update=Greatest(
+                Max("comments__created"), "created", output_field=DateTimeField()
+            )
+        )
     )
     serializer_class = SupportGroupMessageSerializer
     permission_classes = (GlobalOrObjectPermissions,)

--- a/agir/msgs/actions.py
+++ b/agir/msgs/actions.py
@@ -10,10 +10,11 @@ from django.db.models import (
     Max,
     F,
     Q,
+    Value,
 )
-from django.db.models.functions import Greatest
+from django.db.models.functions import Greatest, Coalesce
 
-from agir.groups.models import SupportGroup
+from agir.groups.models import SupportGroup, Membership
 from agir.msgs.models import (
     SupportGroupMessageRecipient,
     SupportGroupMessage,
@@ -29,6 +30,26 @@ def update_recipient_message(message, recipient):
 
 
 def get_unread_message_count(person_pk):
+    unread_comment_count_subquery = Coalesce(
+        Subquery(
+            SupportGroupMessageComment.objects.filter(
+                deleted=False,
+                message_id=OuterRef("id"),
+                created__gt=Greatest(
+                    OuterRef("last_reading_date"),
+                    OuterRef("membership_created"),
+                    OuterRef("created"),
+                ),
+            )
+            .exclude(author_id=person_pk,)
+            .values("message_id")
+            .annotate(count=Count("pk"))
+            .values("count"),
+            output_field=IntegerField(),
+        ),
+        0,
+    )
+
     unread_message_count = (
         SupportGroupMessage.objects.filter(
             deleted=False,
@@ -37,10 +58,10 @@ def get_unread_message_count(person_pk):
             .values("id"),
         )
         .annotate(
-            comment_count=Count(
-                "comments",
-                filter=(Q(comments__deleted=False) & ~Q(comments__author_id=person_pk)),
-                distinct=True,
+            membership_created=Subquery(
+                Membership.objects.filter(
+                    supportgroup_id=OuterRef("supportgroup_id"), person_id=person_pk,
+                ).values("created")[:1]
             )
         )
         .annotate(
@@ -50,27 +71,56 @@ def get_unread_message_count(person_pk):
                 ).values("modified")[:1]
             )
         )
+        .annotate(unread_comment_count=unread_comment_count_subquery)
         .annotate(
             unread_count=Case(
-                # If the message is unread, count 1 for the message plus 1 for each
-                # of the message's comments
-                When(last_reading_date=None, then=F("comment_count") + 1,),
-                # If the message has already been read once, count 1 for each comment
-                # created after the last reading date
-                default=Subquery(
-                    SupportGroupMessageComment.objects.filter(
-                        deleted=False,
-                        message_id=OuterRef("id"),
-                        created__gt=OuterRef("last_reading_date"),
-                    )
-                    .exclude(author_id=person_pk)
-                    .values("message_id")
-                    .annotate(count=Count("pk"))
-                    .values("count"),
+                # If the message is unread and has been created after the person has joined the group,
+                # count 1 for the message plus 1 for each of the message's comments
+                When(
+                    last_reading_date=None,
+                    created__gt=F("membership_created"),
+                    then=F("unread_comment_count") + 1,
                 ),
+                # If the message has already been read once, count 1 for each comment
+                # created after the last reading date and after the person has joined
+                # the group
+                default=F("unread_comment_count"),
             ),
         )
         .values_list("unread_count", flat=True)
     )
 
-    return sum(filter(None, unread_message_count))
+    return sum(unread_message_count)
+
+
+def get_message_unread_comment_count(person_pk, message_pk):
+    return (
+        SupportGroupMessageComment.objects.filter(
+            deleted=False,
+            message_id=message_pk,
+            message__supportgroup_id__in=SupportGroup.objects.active()
+            .filter(memberships__person_id=person_pk)
+            .values("id"),
+        )
+        .exclude(author_id=person_pk)
+        .annotate(
+            membership_created=Subquery(
+                Membership.objects.filter(
+                    supportgroup_id=OuterRef("message__supportgroup_id"),
+                    person_id=person_pk,
+                ).values("created")[:1]
+            )
+        )
+        .annotate(
+            last_reading_date=Subquery(
+                SupportGroupMessageRecipient.objects.filter(
+                    recipient_id=person_pk, message_id=message_pk
+                ).values("modified")[:1]
+            )
+        )
+        .filter(
+            created__gt=Greatest(
+                "last_reading_date", "membership_created", "message__created",
+            ),
+        )
+    ).count()

--- a/agir/msgs/components/MessagePage/MessageThreadList.stories.js
+++ b/agir/msgs/components/MessagePage/MessageThreadList.stories.js
@@ -2,7 +2,7 @@ import _sortBy from "lodash/sortBy";
 import React from "react";
 
 import mockMessages from "@agir/front/mockData/messages";
-
+import { TestGlobalContextProvider } from "@agir/front/globalContext/GlobalContext";
 import MessageThreadList from "./MessageThreadList";
 
 export default {
@@ -27,19 +27,21 @@ const Template = (args) => {
   );
 
   return (
-    <div
-      style={{
-        width: "100%",
-        height: "100vh",
-        padding: "0",
-      }}
-    >
-      <MessageThreadList
-        {...args}
-        selectedMessage={selected}
-        onSelect={setSelectedId}
-      />
-    </div>
+    <TestGlobalContextProvider>
+      <div
+        style={{
+          width: "100%",
+          height: "100vh",
+          padding: "0",
+        }}
+      >
+        <MessageThreadList
+          {...args}
+          selectedMessage={selected}
+          onSelect={setSelectedId}
+        />
+      </div>
+    </TestGlobalContextProvider>
   );
 };
 

--- a/agir/msgs/serializers.py
+++ b/agir/msgs/serializers.py
@@ -5,6 +5,7 @@ from agir.groups.models import SupportGroup
 from agir.events.models import Event
 from agir.events.serializers import EventListSerializer
 from agir.lib.serializers import FlexibleFieldsMixin, CurrentPersonField
+from agir.msgs.actions import get_message_unread_comment_count
 from agir.msgs.models import (
     SupportGroupMessage,
     SupportGroupMessageComment,
@@ -210,14 +211,7 @@ class UserMessagesSerializer(BaseMessageSerializer):
         user = self.context["request"].user
         if not user.is_authenticated or not user.person:
             return 0
-        comment_count = message.comments.count()
-        if comment_count == 0:
-            return 0
-        try:
-            reading_state = message.readers.get(recipient=user.person)
-            return reading_state.unread_comments.count()
-        except SupportGroupMessageRecipient.DoesNotExist:
-            return comment_count
+        return get_message_unread_comment_count(user.person.pk, message.pk)
 
     def get_is_author(self, message):
         user = self.context["request"].user

--- a/agir/msgs/serializers.py
+++ b/agir/msgs/serializers.py
@@ -78,6 +78,7 @@ class SupportGroupMessageSerializer(BaseMessageSerializer):
     )
     DETAIL_FIELDS = (
         "id",
+        "lastUpdate",
         "created",
         "author",
         "text",
@@ -86,6 +87,7 @@ class SupportGroupMessageSerializer(BaseMessageSerializer):
         "comments",
     )
 
+    lastUpdate = serializers.DateTimeField(read_only=True, source="last_update")
     group = serializers.SerializerMethodField(read_only=True)
     linkedEvent = LinkedEventField(
         source="linked_event", required=False, allow_null=True,
@@ -139,6 +141,7 @@ class SupportGroupMessageSerializer(BaseMessageSerializer):
             "recentComments",
             "comments",
             "commentCount",
+            "lastUpdate",
         )
 
 

--- a/agir/msgs/views.py
+++ b/agir/msgs/views.py
@@ -6,6 +6,8 @@ from django.db.models import (
     Max,
     OuterRef,
     When,
+    Prefetch,
+    Count,
 )
 from django.db.models.functions import Greatest
 from rest_framework.decorators import api_view, permission_classes
@@ -15,7 +17,11 @@ from rest_framework.response import Response
 
 from agir.groups.models import Membership, SupportGroup
 from agir.msgs.actions import get_unread_message_count
-from agir.msgs.models import SupportGroupMessage, SupportGroupMessageRecipient
+from agir.msgs.models import (
+    SupportGroupMessage,
+    SupportGroupMessageRecipient,
+    SupportGroupMessageComment,
+)
 from agir.msgs.serializers import (
     UserReportSerializer,
     UserMessagesSerializer,
@@ -68,12 +74,12 @@ class UserMessagesAPIView(ListAPIView):
             .prefetch_related("comments")
             .annotate(is_unread=~Exists(user_message))
             .annotate(
-                last_comment=Greatest(
+                last_update=Greatest(
                     Max("comments__created"), "created", output_field=DateTimeField()
                 )
             )
             .distinct()
-            .order_by("-last_comment", "-created")
+            .order_by("-last_update", "-created")
         )
 
 


### PR DESCRIPTION
- Ajout des informations du dernier commentaires dans le menu de la page messages : mise à jour des composants et de l'API
- Tous les messages / commentaires créés avant qu'une personne rejoigne leur groupe sont automatiquement exclus du décompte des messages / commentaires non lus (à la fois dans le décompte global et dans le décompte de chaque message)