### PR TITLE
Page `Messages` : retours

### DIFF
--- a/agir/front/components/allPages/TopBar/TopBar.js
+++ b/agir/front/components/allPages/TopBar/TopBar.js
@@ -63,6 +63,11 @@ const TopBarContainer = styled.div`
   flex-grow: 1;
   height: 100%;
   align-items: center;
+
+  @media (max-width: ${style.collapse}px) {
+    max-width: 100%;
+    min-width: 0;
+  }
 `;
 
 const HorizontalFlex = styled.div`
@@ -76,6 +81,7 @@ const HorizontalFlex = styled.div`
 
   & > * {
     margin-left: 1.25em;
+    min-width: 0;
   }
 
   form {
@@ -132,6 +138,7 @@ export const TopBar = (props) => {
           ) : null}
           <HorizontalFlex
             center={!isConnected || path === "/" || typeof path === "undefined"}
+            style={{ minWidth: 0 }}
           >
             <Hide over>
               <TopBarMainLink path={path} />

--- a/agir/front/components/allPages/TopBar/TopBarMainLink.js
+++ b/agir/front/components/allPages/TopBar/TopBarMainLink.js
@@ -20,6 +20,9 @@ const TopBarMainLabel = styled.h1`
   font-size: 16px;
   line-height: 24px;
   margin: 1px 0 -1px 0;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow-x: hidden;
 
   &:hover {
     text-decoration: none;
@@ -43,7 +46,11 @@ export const TopBarMainLink = (props) => {
     );
   }
 
-  return <TopBarMainLabel>{pageTitle || currentRoute.label}</TopBarMainLabel>;
+  return (
+    <TopBarMainLabel title={pageTitle || currentRoute.label}>
+      {pageTitle || currentRoute.label}
+    </TopBarMainLabel>
+  );
 };
 
 TopBarMainLink.propTypes = {

--- a/agir/front/components/app/hooks.js
+++ b/agir/front/components/app/hooks.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useHistory } from "react-router-dom";
+import { createGlobalState } from "react-use";
 
 import { parseQueryStringParams } from "@agir/lib/utils/url";
 import { useLocalStorage } from "@agir/lib/utils/hooks";
@@ -54,6 +55,7 @@ export const useMobileApp = () => {
   return state;
 };
 
+const useHasDownloadBanner = createGlobalState(undefined);
 export const useDownloadBanner = () => {
   const [bannerCount, setBannerCount] = useLocalStorage("BANNER_count", 0);
   const [visitCount] = useLocalStorage("AP_vcount", 0);
@@ -61,9 +63,30 @@ export const useDownloadBanner = () => {
   const isDesktop = useIsDesktop();
   const { isMobileApp } = useMobileApp();
 
-  const hide = useCallback(() => {
-    setBannerCount(visitCount + 25);
-  }, [setBannerCount, visitCount]);
+  const [hasBanner, setHasBanner] = useHasDownloadBanner();
 
-  return [!isMobileApp && !isDesktop && bannerCount <= visitCount, hide];
+  useEffect(() => {
+    if (
+      hasBanner !== false &&
+      !isMobileApp &&
+      !isDesktop &&
+      bannerCount <= visitCount
+    ) {
+      setHasBanner(true);
+    }
+  }, [
+    hasBanner,
+    isMobileApp,
+    isDesktop,
+    bannerCount,
+    visitCount,
+    setHasBanner,
+  ]);
+
+  const hide = useCallback(() => {
+    setHasBanner(false);
+    setBannerCount(visitCount + 25);
+  }, [setBannerCount, visitCount, setHasBanner]);
+
+  return [!!hasBanner, hide];
 };

--- a/agir/front/components/formComponents/Comment.js
+++ b/agir/front/components/formComponents/Comment.js
@@ -8,7 +8,6 @@ import { timeAgo } from "@agir/lib/utils/time";
 
 import Avatar from "@agir/front/genericComponents/Avatar";
 import { RawFeatherIcon } from "@agir/front/genericComponents/FeatherIcon";
-import Link from "@agir/front/app/Link";
 import InlineMenu from "@agir/front/genericComponents/InlineMenu";
 import ParsedString from "@agir/front/genericComponents/ParsedString";
 
@@ -87,77 +86,49 @@ const StyledInlineMenuItems = styled.div`
     }
   }
 `;
-const StyledMessageHeader = styled.header``;
-const StyledMessageContent = styled.div``;
+const StyledMessageAuthor = styled.h5``;
+const StyledMessageContent = styled.p``;
+const StyledMessageTime = styled.div``;
 const StyledAction = styled.div``;
 const StyledMessage = styled.div``;
 const StyledWrapper = styled(animated.div)`
   display: flex;
   flex-flow: row nowrap;
+  align-items: flex-start;
   max-width: 100%;
+  padding: 1rem 0;
+  border-top: 1px solid ${(props) => props.theme.black100};
 
-  & + & {
-    margin-top: 1rem;
+  &:first-child {
+    @media (min-width: ${style.collapse}px) {
+      border-top: none;
+    }
   }
 
   ${Avatar} {
     flex: 0 0 auto;
     width: 2rem;
     height: 2rem;
-    margin-top: 5px;
     margin-right: 0.5rem;
   }
 
   ${StyledMessage} {
     display: flex;
+    flex: 1 1 auto;
     border-radius: 8px;
-    background-color: ${style.black50};
     flex-direction: row;
-    padding: 0.75rem;
-  }
-
-  ${StyledMessageHeader} {
-    font-size: 0.875rem;
-    display: flex;
-    flex-direction: row;
-    align-items: baseline;
-
-    @media (max-width: ${style.collapse}px) {
-      flex-direction: column;
-      align-items: flex-start;
-    }
-
-    strong {
-      font-weight: 700;
-      font-size: 0.875rem;
-
-      a {
-        margin-left: 0.25rem;
-        text-decoration: underline;
-        font-weight: 500;
-        line-height: inherit;
-      }
-    }
-
-    em {
-      font-weight: normal;
-      font-size: 13px;
-      color: ${style.black700};
-      margin-left: 0.5rem;
-      font-style: normal;
-
-      @media (max-width: ${style.collapse}px) {
-        margin: 0.25rem 0;
-      }
-    }
   }
 
   ${StyledMessageContent} {
+    flex: 1 1 auto;
     font-size: 0.875rem;
+    margin: 0;
 
-    strong {
-      font-weight: 600;
-      font-size: inherit;
+    ${StyledMessageAuthor} {
+      padding: 0;
+      margin: 0;
+      font-weight: 700;
+      font-size: 0.875rem;
     }
 
     article {
@@ -169,9 +140,16 @@ const StyledWrapper = styled(animated.div)`
     }
   }
 
+  ${StyledMessageTime} {
+    padding: 0 1rem;
+    flex: 0 0 auto;
+    font-size: 0.813rem;
+    color: ${style.black700};
+    font-style: normal;
+  }
+
   ${StyledAction} {
     flex: 0 0 auto;
-    margin-left: 1rem;
   }
 `;
 
@@ -203,17 +181,14 @@ const Comment = (props) => {
       <Avatar {...author} />
       <StyledMessage>
         <StyledMessageContent>
-          <StyledMessageHeader>
-            <strong>
-              {author.displayName || (isAuthor && "Moi") || "Quelqu'un"}
-              {!author.displayName && isAuthor && (
-                <Link route="personalInformation">Ajouter mon nom</Link>
-              )}
-            </strong>
-            <em>{created ? timeAgo(created) : null}</em>
-          </StyledMessageHeader>
+          <StyledMessageAuthor>
+            {author.displayName || (isAuthor && "Moi") || "Quelqu'un"}
+          </StyledMessageAuthor>
           <ParsedString as="article">{text}</ParsedString>
         </StyledMessageContent>
+        <StyledMessageTime>
+          {created ? timeAgo(created) : null}
+        </StyledMessageTime>
         {hasActions ? (
           <StyledAction>
             <InlineMenu

--- a/agir/front/components/genericComponents/MessageCard.js
+++ b/agir/front/components/genericComponents/MessageCard.js
@@ -237,14 +237,9 @@ const StyledComments = styled.div`
   justify-content: flex-start;
 
   @media (min-width: ${style.collapse}px) {
-    border-top: 1px solid ${style.black100};
-    transform: translateY(0.5rem);
-    padding-top: 1.5rem;
-
-    &:empty {
-      border-top: none;
-      transform: none;
-    }
+    border-top: ${({ $empty }) =>
+      $empty ? "none" : `1px solid ${style.black100}`};
+    transform: ${({ $empty }) => ($empty ? "none" : "translateY(0.5rem)")};
   }
 
   ${StyledNewComment} {
@@ -516,7 +511,9 @@ const MessageCard = (props) => {
             &ensp;Voir les {commentCount} commentaires
           </StyledCommentCount>
         ) : null}
-        <StyledComments>
+        <StyledComments
+          $empty={!Array.isArray(comments) || comments.length === 0}
+        >
           <PageFadeIn ready={Array.isArray(comments) && comments.length > 0}>
             {Array.isArray(comments) && comments.length > 0
               ? comments.map((comment) => (

--- a/agir/front/components/genericComponents/grid.js
+++ b/agir/front/components/genericComponents/grid.js
@@ -41,6 +41,8 @@ export const PullRight = styled.div`
  * Media queries
  */
 export const Hide = styled.div`
+  min-width: 0;
+
   @media (max-width: ${({ under }) => (under === true ? collapse : under)}px) {
     display: none;
   }

--- a/agir/msgs/components/MessagePage/MessageThreadList.js
+++ b/agir/msgs/components/MessagePage/MessageThreadList.js
@@ -56,6 +56,12 @@ const StyledList = styled.main`
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
+
+    &:first-child {
+      @media (min-width: ${style.collapse}px) {
+        flex: 0 0 400px;
+      }
+    }
   }
 `;
 

--- a/agir/msgs/components/MessagePage/MessageThreadList.js
+++ b/agir/msgs/components/MessagePage/MessageThreadList.js
@@ -161,7 +161,6 @@ const DesktopThreadList = (props) => {
               isManager={selectedMessage.group.isManager}
               groupURL={routeConfig.groupDetails.getLink({
                 groupPk: selectedMessage.group.id,
-                activeTab: "messages",
               })}
             />
           ) : null}
@@ -238,7 +237,6 @@ const MobileThreadList = (props) => {
               isManager={selectedMessage?.group.isManager}
               groupURL={routeConfig.groupDetails.getLink({
                 groupPk: selectedMessage?.group.id,
-                activeTab: "messages",
               })}
             />
           )}

--- a/agir/notifications/serializers/activity_notifications.py
+++ b/agir/notifications/serializers/activity_notifications.py
@@ -381,6 +381,8 @@ class NewMessageActivityNotificationSerializer(ActivityNotificationSerializer):
     def get_body(self, activity):
         try:
             message = SupportGroupMessage.objects.get(pk=activity.meta["message"])
+            if message.subject:
+                return message.subject
             return message.text
         except:
             return f"Un nouveau message a été publié dans le groupe {activity.supportgroup.name}"


### PR DESCRIPTION
- Garder le titre de page dans la top bar mobile sur une seule ligne
- Fixer la taille de la liste des messages à 400px sur desktop
- Le lien de groupe dans le message renvoie vers l'accueil de la page de groupe