### PR TITLE
Post-prod message page fixes

### DIFF
--- a/agir/front/components/genericComponents/Panel.js
+++ b/agir/front/components/genericComponents/Panel.js
@@ -143,7 +143,7 @@ const PanelFrame = styled.div`
         if ($isBehindTopBar) {
           return "56px";
         }
-        return "0";
+        return "1.5rem";
       }};
     }
   }

--- a/agir/front/views.py
+++ b/agir/front/views.py
@@ -7,13 +7,13 @@ from django.http import (
     HttpResponsePermanentRedirect,
     Http404,
     FileResponse,
-    HttpResponse,
 )
+from django.shortcuts import get_object_or_404
 from django.templatetags.static import static
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.decorators import cache
-from django.views.generic import View, RedirectView, TemplateView
+from django.views.generic import View, RedirectView
 from django.views.generic.detail import BaseDetailView
 
 from agir.authentication.view_mixins import (
@@ -310,8 +310,11 @@ class UserMessagesView(HardLoginRequiredMixin, ReactBaseView):
 
 
 class UserMessageView(
-    GlobalOrObjectPermissionRequiredMixin, HardLoginRequiredMixin, ReactBaseView
+    GlobalOrObjectPermissionRequiredMixin, HardLoginRequiredMixin, ReactBaseView,
 ):
     permission_required = ("msgs.view_message",)
     queryset = SupportGroupMessage.objects.all()
     bundle_name = "front/app"
+
+    def get_object(self):
+        return get_object_or_404(self.queryset, pk=self.kwargs.get("pk"))

--- a/agir/msgs/components/hooks.js
+++ b/agir/msgs/components/hooks.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import useSWR, { mutate } from "swr";
+import { validate as uuidValidate } from "uuid";
 
 import axios from "@agir/lib/utils/axios";
 import * as groupAPI from "@agir/groups/groupPage/api";
@@ -34,7 +35,11 @@ export const useMessageSWR = (messagePk, selectMessage) => {
     error,
     isValidating,
     mutate: mutateMessage,
-  } = useSWR(messagePk ? `/api/groupes/messages/${messagePk}/` : null);
+  } = useSWR(
+    messagePk && uuidValidate(messagePk)
+      ? `/api/groupes/messages/${messagePk}/`
+      : null
+  );
   const { pathname } = useLocation();
 
   const currentMessageId = currentMessage?.id;

--- a/agir/msgs/rules.py
+++ b/agir/msgs/rules.py
@@ -1,0 +1,29 @@
+import rules
+
+from agir.msgs.models import SupportGroupMessage
+
+
+@rules.predicate
+def is_authenticated_person(role):
+    return role.is_authenticated and hasattr(role, "person")
+
+
+@rules.predicate
+def is_own_group_message(role, message=None):
+    if message is None:
+        return False
+
+    if isinstance(message, SupportGroupMessage):
+        supportgroup = message.supportgroup
+    else:
+        return False
+
+    return (
+        supportgroup is not None
+        and supportgroup.members.filter(pk=role.person.pk).exists()
+    )
+
+
+rules.add_perm(
+    "msgs.view_message", is_authenticated_person & is_own_group_message,
+)


### PR DESCRIPTION
- Fix des permission de la vue `UserMessageView` : ajout d'une règle `msgs.view_message` et d'une methode `get_object` à la vue
- Fix du padding supérieur du composant `Panel`
- Fix d'un malentendu avec le hook `useMessageSWR` concernant la récupération via l'API des données d'un message : le hook était convaincu que le _parametres_ dans le chemin `/messages/parametres/` était un id de message valide