### PR TITLE
Create ping API endpoint to allow caching of the session

### DIFF
--- a/agir/authentication/urls.py
+++ b/agir/authentication/urls.py
@@ -9,6 +9,7 @@ from .views import (
     LoginAPIView,
     CheckCodeAPIView,
     LogoutAPIView,
+    ping,
 )
 
 
@@ -29,6 +30,7 @@ urlpatterns = [
         name="social_login_error",
     ),
     path("api/session/", SessionContextAPIView.as_view(), name="api_session"),
+    path("api/ping/", ping, name="api_ping"),
     path("api/connexion/", LoginAPIView.as_view(), name="api_login"),
     path("api/connexion/code/", CheckCodeAPIView.as_view(), name="api_check_code"),
     path("api/deconnexion/", LogoutAPIView.as_view(), name="api_logout"),

--- a/agir/authentication/views/api_views.py
+++ b/agir/authentication/views/api_views.py
@@ -3,8 +3,10 @@ from django.contrib.auth import authenticate, login, logout
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.middleware.csrf import get_token
+from django.views.decorators.cache import never_cache
 
 from rest_framework import exceptions, permissions, status
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.generics import CreateAPIView, RetrieveAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -22,6 +24,7 @@ __all__ = [
     "LoginAPIView",
     "CheckCodeAPIView",
     "LogoutAPIView",
+    "ping",
 ]
 
 send_mail_email_bucket = TokenBucket("SendMail", 5, 600)
@@ -48,6 +51,13 @@ class SessionContextAPIView(RetrieveAPIView):
 
     def get_object(self):
         return self.request
+
+
+@never_cache
+@api_view(["GET"])
+@permission_classes(())
+def ping(request):
+    return Response("pong")
 
 
 class LoginAPIView(APIView):

--- a/agir/front/components/offline/hooks.js
+++ b/agir/front/components/offline/hooks.js
@@ -6,7 +6,9 @@ import logger from "@agir/lib/utils/logger";
 const log = logger(__filename);
 
 export const useIsOffline = () => {
-  const { data, error, isValidating } = useSWR("/api/session/");
+  const { data, error, isValidating } = useSWR("/api/ping/", {
+    refreshInterval: 10000,
+  });
   const [unloading, setUnloading] = useState(false);
 
   log.debug(`Unloading : ${unloading}`, unloading);

--- a/agir/front/components/serviceWorker/serviceWorker.js
+++ b/agir/front/components/serviceWorker/serviceWorker.js
@@ -16,12 +16,13 @@ webpackAssets.unshift({
 });
 precacheAndRoute(webpackAssets);
 
-// Use network first for HTML
+// Use network only for HTML and for pinging the API
 registerRoute(
   // Check to see if the request is a navigation to a new page
   ({ request }) => request.mode === "navigate",
   new NetworkOnly()
 );
+registerRoute("/api/ping/", new NetworkOnly());
 
 // Use network first or stale cache for some API endpoints
 


### PR DESCRIPTION
La manière dont on vérifie si l'application est connectée ou pas à internet actuellement : 
- on fait un appel à l'endpoint `api/session/`
- si la réponse n'est pas une erreur, on considère que l'application est online (et on affiche un bandeau vert avec le message `Connexion rétablie` si elle était offline jusque-là)
- si la réponse est une erreur, on considère que l'application est offline (et on affiche un bandeau rouge avec le message `Aucune connexion internet`)

Ce système ne fonctionne pas aujourd'hui car les réponses 2xx de l'endpoint `api/session/` sont mises en cache par le service worker : même en cas de déconnexion il est donc possible qu'il n'y ait pas de réponse d'erreur.

Pour éviter ce problème et garder le cache de la session hors connexion, j'ai créé un nouvel endpoint `api/ping/` qui n'est jamais mis en cache et dont le seul but est de permettre de vérifier la communication entre le client et l'API.

