### PR TITLE
Add `font-display: fallback` to font.css

### DIFF
--- a/agir/front/components/allPages/fonts/fonts.css
+++ b/agir/front/components/allPages/fonts/fonts.css
@@ -1,5 +1,6 @@
 /* poppins-300 - latin-ext_latin */
 @font-face {
+  font-display: fallback;
   font-family: "Poppins";
   font-style: normal;
   font-weight: 300;
@@ -15,6 +16,7 @@
 
 /* poppins-300italic - latin-ext_latin */
 @font-face {
+  font-display: fallback;
   font-family: "Poppins";
   font-style: italic;
   font-weight: 300;
@@ -32,23 +34,23 @@
 
 /* poppins-regular - latin-ext_latin */
 @font-face {
+  font-display: fallback;
   font-family: "Poppins";
   font-style: normal;
   font-weight: 400;
   src: url("poppins-regular.eot");
   /* IE9 Compat Modes */
-  src: local(""),
-    url("poppins-regular.eot?#iefix") format("embedded-opentype"),
+  src: local(""), url("poppins-regular.eot?#iefix") format("embedded-opentype"),
     /* IE6-IE8 */ url("poppins-regular.woff2") format("woff2"),
     /* Super Modern Browsers */ url("poppins-regular.woff") format("woff"),
     /* Modern Browsers */ url("poppins-regular.ttf") format("truetype"),
-    /* Safari, Android, iOS */ url("poppins-regular.svg#Poppins")
-      format("svg");
+    /* Safari, Android, iOS */ url("poppins-regular.svg#Poppins") format("svg");
   /* Legacy iOS */
 }
 
 /* poppins-italic - latin-ext_latin */
 @font-face {
+  font-display: fallback;
   font-family: "Poppins";
   font-style: italic;
   font-weight: 400;
@@ -64,6 +66,7 @@
 
 /* poppins-500 - latin-ext_latin */
 @font-face {
+  font-display: fallback;
   font-family: "Poppins";
   font-style: normal;
   font-weight: 500;
@@ -79,6 +82,7 @@
 
 /* poppins-500italic - latin-ext_latin */
 @font-face {
+  font-display: fallback;
   font-family: "Poppins";
   font-style: italic;
   font-weight: 500;
@@ -96,6 +100,7 @@
 
 /* poppins-600 - latin-ext_latin */
 @font-face {
+  font-display: fallback;
   font-family: "Poppins";
   font-style: normal;
   font-weight: 600;
@@ -111,6 +116,7 @@
 
 /* poppins-600italic - latin-ext_latin */
 @font-face {
+  font-display: fallback;
   font-family: "Poppins";
   font-style: italic;
   font-weight: 600;
@@ -128,6 +134,7 @@
 
 /* poppins-700 - latin-ext_latin */
 @font-face {
+  font-display: fallback;
   font-family: "Poppins";
   font-style: normal;
   font-weight: 700;
@@ -143,6 +150,7 @@
 
 /* poppins-700italic - latin-ext_latin */
 @font-face {
+  font-display: fallback;
   font-family: "Poppins";
   font-style: italic;
   font-weight: 700;


### PR DESCRIPTION
fallback: Acts as a compromise between the auto and swap values. The browser will hide the text for about 100ms and, if the font has not yet been downloaded, will use the fallback text. It will swap to the new font after it is downloaded, but only during a short swap period (probably 3 seconds).

cf. https://css-tricks.com/almanac/properties/f/font-display/#values