### PR TITLE
Offline display fixes

### DIFF
--- a/agir/activity/components/ActivityPage/ActivityList.js
+++ b/agir/activity/components/ActivityPage/ActivityList.js
@@ -4,6 +4,7 @@ import useSWR from "swr";
 
 import style from "@agir/front/genericComponents/_variables.scss";
 
+import { useIsOffline } from "@agir/front/offline/hooks";
 import { useSelector } from "@agir/front/globalContext/GlobalContext";
 import { getRoutes } from "@agir/front/globalContext/reducers";
 import { getUnread } from "@agir/activity/common/helpers";
@@ -22,6 +23,7 @@ import { PageFadeIn } from "@agir/front/genericComponents/PageFadeIn";
 import Skeleton from "@agir/front/genericComponents/Skeleton";
 
 import NotificationSettingLink from "@agir/activity/NotificationSettings/NotificationSettingLink";
+import NotFoundPage from "@agir/front/notFoundPage/NotFoundPage";
 
 import ActivityCard from "./ActivityCard";
 import ActivityMergerAnnouncement from "./ActivityMergerAnnouncement";
@@ -54,6 +56,7 @@ const Page = styled.article`
 `;
 
 const ActivityList = () => {
+  const isOffline = useIsOffline();
   const routes = useSelector(getRoutes);
 
   const { data: session } = useSWR("/api/session/");
@@ -114,6 +117,8 @@ const ActivityList = () => {
                 )}
                 {isLoadingMore && <Skeleton />}
               </StyledList>
+            ) : isOffline ? (
+              <NotFoundPage isTopBar={false} reloadOnReconnection={false} />
             ) : (
               <EmptyActivityList />
             )}

--- a/agir/events/components/eventPage/EventPage.js
+++ b/agir/events/components/eventPage/EventPage.js
@@ -3,7 +3,12 @@ import { DateTime, Interval } from "luxon";
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
 import styled from "styled-components";
+import useSWR from "swr";
 
+import style from "@agir/front/genericComponents/_variables.scss";
+
+import logger from "@agir/lib/utils/logger";
+import * as api from "@agir/events/common/api";
 import {
   useDispatch,
   useSelector,
@@ -17,9 +22,9 @@ import {
   getIsConnected,
   getIsSessionLoaded,
 } from "@agir/front/globalContext/reducers";
+import { useIsOffline } from "@agir/front/offline/hooks";
 
 import Link from "@agir/front/app/Link";
-
 import EventHeader from "./EventHeader";
 import EventLocationCard from "./EventLocationCard";
 import EventFacebookLinkCard from "./EventFacebookLinkCard";
@@ -38,13 +43,7 @@ import Card from "@agir/front/genericComponents/Card";
 import GroupCard from "@agir/groups/groupComponents/GroupCard";
 import Map from "@agir/carte/common/Map";
 import NotFoundPage from "@agir/front/notFoundPage/NotFoundPage.js";
-
-import style from "@agir/front/genericComponents/_variables.scss";
-import useSWR from "swr";
 import Skeleton from "@agir/front/genericComponents/Skeleton";
-
-import logger from "@agir/lib/utils/logger";
-import * as api from "@agir/events/common/api";
 
 import defaultEventImage from "@agir/front/genericComponents/images/banner-map-background.svg";
 
@@ -372,6 +371,7 @@ const MobileSkeleton = () => (
 
 export const ConnectedEventPage = (props) => {
   const { eventPk } = props;
+  const isOffline = useIsOffline();
   const isConnected = useSelector(getIsConnected);
   const isSessionLoaded = useSelector(getIsSessionLoaded);
   const dispatch = useDispatch();
@@ -412,12 +412,17 @@ export const ConnectedEventPage = (props) => {
     }
   }, [eventData, dispatch]);
 
-  if ([403, 404].includes(error?.response?.status))
+  if (
+    error?.message === "NetworkError" ||
+    [403, 404].includes(error?.response?.status) ||
+    (isOffline && !eventData)
+  )
     return (
       <NotFoundPage
         isTopBar={false}
         title="Événement"
         subtitle="Cet événement"
+        reloadOnReconnection={false}
       />
     );
 

--- a/agir/front/components/app/ConnectivityWarning.js
+++ b/agir/front/components/app/ConnectivityWarning.js
@@ -1,9 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { useIsOffline } from "@agir/front/offline/hooks";
-import logger from "@agir/lib/utils/logger";
 import { animated, useTransition } from "@react-spring/web";
 import styled from "styled-components";
-import styles from "@agir/front/genericComponents/_variables.scss";
+
+import { useIsOffline } from "@agir/front/offline/hooks";
+import { useDownloadBanner } from "@agir/front/app/hooks.js";
+import logger from "@agir/lib/utils/logger";
+
 import style from "@agir/front/genericComponents/_variables.scss";
 
 const log = logger(__filename);
@@ -15,7 +17,15 @@ const StyledWarning = styled(animated.div)`
   z-index: ${style.zindexTopBar};
 
   @media (max-width: ${style.collapse}px) {
-    top: ${({ $hasTopBar }) => ($hasTopBar ? "56px" : "0")};
+    top: ${({ $hasTopBar, $hasDownloadBanner }) => {
+      if ($hasTopBar && $hasDownloadBanner) {
+        return "136px";
+      }
+      if ($hasTopBar) {
+        return "56px";
+      }
+      return "0";
+    }};
   }
 
   & > div {
@@ -32,6 +42,7 @@ const StyledWarning = styled(animated.div)`
 `;
 
 const ConnectivityWarning = ({ hasTopBar }) => {
+  const [hasDownloadBanner] = useDownloadBanner();
   const offline = useIsOffline();
   log.debug(`Offline ${offline}`);
   const [display, setDisplay] = useState(offline);
@@ -40,11 +51,11 @@ const ConnectivityWarning = ({ hasTopBar }) => {
   const [backgroundColor, color, warning] = useMemo(() => {
     switch (offline) {
       case false:
-        return [styles.green500, styles.green100, "Connexion rétablie"];
+        return [style.green500, style.green100, "Connexion rétablie"];
       case true:
-        return [styles.redNSP, styles.red100, "Aucune connexion internet"];
+        return [style.redNSP, style.red100, "Aucune connexion internet"];
       default:
-        return [styles.primary500, styles.primary100, "Connexion en cours..."];
+        return [style.primary500, style.primary100, "Connexion en cours..."];
     }
   }, [offline]);
 
@@ -69,6 +80,7 @@ const ConnectivityWarning = ({ hasTopBar }) => {
             color,
           }}
           $hasTopBar={hasTopBar}
+          $hasDownloadBanner={hasDownloadBanner}
         >
           <div>{warning}</div>
         </StyledWarning>

--- a/agir/front/components/notFoundPage/NotFoundPage.js
+++ b/agir/front/components/notFoundPage/NotFoundPage.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
+import { usePrevious } from "react-use";
 import styled from "styled-components";
 
 import style from "@agir/front/genericComponents/_variables.scss";
@@ -65,24 +66,21 @@ const OfflineBlock = styled.div`
   }
 `;
 
-// Most of the time, if we are in the app on unknow URL, it is because of service worker no network handling
 export const NotFoundPage = ({
   isTopBar = true,
   title = "Page",
   subtitle = "Cette page",
+  reloadOnReconnection = true,
 }) => {
   const isOffline = useIsOffline();
+  const wasOffline = usePrevious(isOffline);
 
-  // We try to reload every 5 second
   useEffect(() => {
-    if (!isOffline) {
-      return;
-    }
-
-    setTimeout(() => {
+    reloadOnReconnection &&
+      wasOffline &&
+      !isOffline &&
       window.location.reload();
-    }, 5000);
-  }, [isOffline]);
+  }, [reloadOnReconnection, isOffline, wasOffline]);
 
   if (isOffline === null) return null;
 
@@ -134,5 +132,6 @@ NotFoundPage.propTypes = {
   isTopBar: PropTypes.bool,
   title: PropTypes.string,
   subtitle: PropTypes.string,
+  reloadOnReconnection: PropTypes.bool,
 };
 export default NotFoundPage;

--- a/agir/front/components/offline/hooks.js
+++ b/agir/front/components/offline/hooks.js
@@ -8,6 +8,7 @@ const log = logger(__filename);
 export const useIsOffline = () => {
   const { data, error, isValidating } = useSWR("/api/ping/", {
     refreshInterval: 10000,
+    refreshWhenOffline: true,
   });
   const [unloading, setUnloading] = useState(false);
 

--- a/agir/groups/components/groupPage/GroupMessagePage/index.js
+++ b/agir/groups/components/groupPage/GroupMessagePage/index.js
@@ -5,6 +5,7 @@ import { Redirect } from "react-router-dom";
 
 import { routeConfig } from "@agir/front/app/routes.config";
 import { useGroupMessage } from "@agir/groups/groupPage/hooks";
+import { useIsOffline } from "@agir/front/offline/hooks";
 
 import {
   useDispatch,
@@ -18,6 +19,7 @@ import {
 } from "@agir/front/globalContext/reducers";
 
 import CenteredLayout from "@agir/front/dashboardComponents/CenteredLayout";
+import NotFoundPage from "@agir/front/notFoundPage/NotFoundPage";
 import PageFadeIn from "@agir/front/genericComponents/PageFadeIn";
 import Skeleton from "@agir/front/genericComponents/Skeleton";
 
@@ -27,6 +29,7 @@ import UnavailableMessagePage from "./UnavailableMessagePage";
 const PageSkeleton = <Skeleton />;
 
 const Page = ({ groupPk, messagePk }) => {
+  const isOffline = useIsOffline();
   const isSessionLoaded = useSelector(getIsSessionLoaded);
   const backLink = useSelector(getBackLink);
   const user = useSelector(getUser);
@@ -84,6 +87,10 @@ const Page = ({ groupPk, messagePk }) => {
       );
     }
   }, [group, dispatch]);
+
+  if (isOffline && (!group || !message)) {
+    return <NotFoundPage reloadOnReconnection={false} isTopBar={false} />;
+  }
 
   if (
     !isLoading &&

--- a/agir/groups/components/groupPage/GroupPage/GroupPage.js
+++ b/agir/groups/components/groupPage/GroupPage/GroupPage.js
@@ -23,7 +23,12 @@ export const GroupPage = (props) => {
       }
     >
       {group === false ? (
-        <NotFoundPage isTopBar={false} title="Groupe" subtitle="Ce groupe" />
+        <NotFoundPage
+          isTopBar={false}
+          title="Groupe"
+          subtitle="Ce groupe"
+          reloadOnReconnection={false}
+        />
       ) : (
         <ResponsiveLayout
           {...props}
@@ -38,5 +43,6 @@ export const GroupPage = (props) => {
 GroupPage.propTypes = {
   isLoading: PropTypes.bool,
   activeTab: PropTypes.string,
+  group: PropTypes.object,
 };
 export default GroupPage;

--- a/agir/groups/components/groupPage/hooks/group.js
+++ b/agir/groups/components/groupPage/hooks/group.js
@@ -3,16 +3,24 @@ import useSWR from "swr";
 import logger from "@agir/lib/utils/logger";
 
 import * as api from "@agir/groups/groupPage/api";
+import { useIsOffline } from "@agir/front/offline/hooks";
 
 const log = logger(__filename);
 
 export const useGroup = (groupPk) => {
+  const isOffline = useIsOffline();
   const { data, error } = useSWR(
     api.getGroupPageEndpoint("getGroup", { groupPk })
   );
   log.debug("Group data", data);
 
-  if ([403, 404].includes(error?.response?.status)) return false;
+  if (
+    error?.name === "NetworkError" ||
+    [403, 404].includes(error?.response?.status) ||
+    (isOffline && !data)
+  )
+    return false;
+
   return data;
 };
 

--- a/agir/msgs/components/MessagePage/MessagePage.js
+++ b/agir/msgs/components/MessagePage/MessagePage.js
@@ -13,6 +13,7 @@ import {
 import { useDispatch } from "@agir/front/globalContext/GlobalContext";
 import { setPageTitle } from "@agir/front/globalContext/actions";
 import { getMessageSubject } from "@agir/msgs/utils";
+import { useIsOffline } from "@agir/front/offline/hooks";
 
 import { Hide } from "@agir/front/genericComponents/grid";
 import MessageActionModal from "@agir/front/formComponents/MessageActionModal";
@@ -21,6 +22,7 @@ import Navigation from "@agir/front/dashboardComponents/Navigation";
 import NotificationSettings from "@agir/activity/NotificationSettings/NotificationSettings";
 import PageFadeIn from "@agir/front/genericComponents/PageFadeIn";
 import Skeleton from "@agir/front/genericComponents/Skeleton";
+import NotFoundPage from "@agir/front/notFoundPage/NotFoundPage";
 
 import MessageThreadList from "./MessageThreadList";
 import EmptyMessagePage from "./EmptyMessagePage";
@@ -46,6 +48,7 @@ const StyledPage = styled.div`
 `;
 
 const MessagePage = ({ messagePk }) => {
+  const isOffline = useIsOffline();
   const dispatch = useDispatch();
   const onSelectMessage = useSelectMessage();
   const { user, messages, messageRecipients, currentMessage } = useMessageSWR(
@@ -96,53 +99,59 @@ const MessagePage = ({ messagePk }) => {
       </Helmet>
       <NotificationSettings />
       <StyledPage>
-        <StyledPageFadeIn
-          ready={user && typeof messages !== "undefined"}
-          wait={<Skeleton />}
-        >
-          {!!writeNewMessage && (
-            <MessageModal
-              shouldShow={shouldShowMessageModal}
-              onClose={dismissMessageAction}
-              user={user}
-              groups={messageRecipients}
-              onSelectGroup={getSelectedGroupEvents}
-              events={selectedGroupEvents}
-              isLoading={isLoading}
-              message={messageAction === "edit" ? currentMessage : null}
-              onSend={saveMessage}
-            />
-          )}
-          {currentMessage && (
-            <MessageActionModal
-              action={shouldShowMessageActionModal ? messageAction : undefined}
-              shouldShow={shouldShowMessageActionModal}
-              onClose={dismissMessageAction}
-              onDelete={onDelete}
-              onReport={onReport}
-              isLoading={isLoading}
-            />
-          )}
-          {Array.isArray(messages) && messages.length > 0 ? (
-            <MessageThreadList
-              isLoading={isLoading}
-              messages={messages}
-              selectedMessagePk={messagePk}
-              selectedMessage={currentMessage}
-              onSelect={onSelectMessage}
-              onEdit={editMessage}
-              onDelete={confirmDelete}
-              onReport={confirmReport}
-              onDeleteComment={confirmDeleteComment}
-              onReportComment={confirmReportComment}
-              user={user}
-              writeNewMessage={writeNewMessage}
-              onComment={writeNewComment}
-            />
-          ) : (
-            <EmptyMessagePage />
-          )}
-        </StyledPageFadeIn>
+        {!isOffline || !messages ? (
+          <StyledPageFadeIn
+            ready={user && typeof messages !== "undefined"}
+            wait={<Skeleton />}
+          >
+            {!!writeNewMessage && (
+              <MessageModal
+                shouldShow={shouldShowMessageModal}
+                onClose={dismissMessageAction}
+                user={user}
+                groups={messageRecipients}
+                onSelectGroup={getSelectedGroupEvents}
+                events={selectedGroupEvents}
+                isLoading={isLoading}
+                message={messageAction === "edit" ? currentMessage : null}
+                onSend={saveMessage}
+              />
+            )}
+            {currentMessage && (
+              <MessageActionModal
+                action={
+                  shouldShowMessageActionModal ? messageAction : undefined
+                }
+                shouldShow={shouldShowMessageActionModal}
+                onClose={dismissMessageAction}
+                onDelete={onDelete}
+                onReport={onReport}
+                isLoading={isLoading}
+              />
+            )}
+            {Array.isArray(messages) && messages.length > 0 ? (
+              <MessageThreadList
+                isLoading={isLoading}
+                messages={messages}
+                selectedMessagePk={messagePk}
+                selectedMessage={currentMessage}
+                onSelect={onSelectMessage}
+                onEdit={editMessage}
+                onDelete={confirmDelete}
+                onReport={confirmReport}
+                onDeleteComment={confirmDeleteComment}
+                onReportComment={confirmReportComment}
+                user={user}
+                writeNewMessage={writeNewMessage}
+                onComment={writeNewComment}
+              />
+            ) : (
+              <EmptyMessagePage />
+            )}
+          </StyledPageFadeIn>
+        ) : (
+          <NotFoundPage isTopBar={false} reloadOnReconnection={false} />
+        )}
       </StyledPage>
       <Hide over>
         <Navigation active="messages" />


### PR DESCRIPTION
- do not stop calling ping API if offline
- display the offline NotFoundPage if offline and no data is cached on the following pages :
  - event details, group details, messages, notifications, group message
- fix the ConnectivityWarning position if the download banner is present
- on legacy pages' NotFoundPage, try to reload the page only once back online (instead of trying to reload it every 5 seconds)