### PR TITLE
Create used fontawesome icon Storybook index

### DIFF
--- a/agir/front/components/genericComponents/Fontawesome.stories.js
+++ b/agir/front/components/genericComponents/Fontawesome.stories.js
@@ -1,0 +1,131 @@
+import fontawesome from "fontawesome";
+import React from "react";
+
+export default {
+  component: "Fontawesome",
+  title: "Generic/Fontawesome",
+};
+
+const usedIcons = [
+  "arrow-left",
+  "arrow-right",
+  "arrow-up",
+  "bars",
+  "bicycle",
+  "bolt",
+  "book",
+  "bug",
+  "bullhorn",
+  "bus",
+  "calendar",
+  "car",
+  "cog",
+  "comment",
+  "comments",
+  "copy",
+  "credit-card",
+  "cutlery",
+  "desktop",
+  "download",
+  "edit",
+  "envelope",
+  "envelope-open",
+  "exclamation",
+  "external-link",
+  "film",
+  "flag",
+  "futbol-o",
+  "glass",
+  "globe",
+  "graduation-cap",
+  "handshake-o",
+  "heart",
+  "industry",
+  "info-circle",
+  "link",
+  "long-arrow-right",
+  "map",
+  "map-marker",
+  "pagelines",
+  "paint-brush",
+  "pencil",
+  "plane",
+  "plus",
+  "refresh",
+  "search",
+  "star-half",
+  "star-half-o",
+  "tint",
+  "trash",
+  "truck",
+  "tv",
+  "undo",
+  "university",
+  "user-circle",
+  "users",
+  "warning",
+];
+
+export const Icons = () => {
+  return (
+    <div
+      style={{
+        padding: "1rem",
+        margin: 0,
+        maxWidth: "992px",
+        width: "100%",
+        display: "grid",
+        fontSize: "0.875rem",
+        gridTemplateColumns: "repeat( auto-fit, minmax(180px, 1fr))",
+      }}
+    >
+      {usedIcons.sort().map((icon) => (
+        <figure
+          key={icon}
+          style={{
+            display: "flex",
+            alignItems: "stretch",
+            margin: 0,
+            padding: 0,
+          }}
+        >
+          <svg
+            width="40"
+            height="44"
+            viewBox="0 0 40 44"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19.4125 36.53L19.7578 36.8915L20.1032 36.53L29.8864 26.2879C35.4834 20.4284 35.4342 10.8888 29.7907 4.98059C24.1473 -0.927579 15.035 -0.979031 9.43801 4.88049C3.84101 10.74 3.89016 20.2796 9.53364 26.1878L19.4125 36.53Z"
+              fill="#e93a55"
+              stroke="white"
+              strokeWidth="2px"
+            />
+            <text
+              x="50%"
+              y="16"
+              dominantBaseline="central"
+              textAnchor="middle"
+              fontFamily="FontAwesome"
+              fontSize="16px"
+              fill="#FFFFFF"
+            >
+              {fontawesome(icon)}
+            </text>
+          </svg>
+          <figcaption>
+            <a
+              href={`https://fontawesome.com/v4.7/icon/${icon}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ lineHeight: "32px", color: "inherit" }}
+            >
+              {icon}
+            </a>
+          </figcaption>
+        </figure>
+      ))}
+    </div>
+  );
+};

--- a/agir/municipales/templates/municipales/commune_details_tour_1.html
+++ b/agir/municipales/templates/municipales/commune_details_tour_1.html
@@ -34,7 +34,7 @@
       {% if commune.website %}
         <p><i class="fa fa-link" aria-hidden="true"></i> <a href="{{ commune.website }}">{{ commune.website }}</a></p>{% endif %}
       {% if commune.contact_email %}
-        <p><i class="fa fa-email" aria-hidden="true"></i> <a href="mailto:{{ commune.contact_email }}">{{ commune.contact_email }}</a>
+        <p><i class="fa fa-envelope" aria-hidden="true"></i> <a href="mailto:{{ commune.contact_email }}">{{ commune.contact_email }}</a>
         </p>{% endif %}
 
       <a href="{% url "procuration_commune" commune.code_departement commune.slug %}">


### PR DESCRIPTION
Related to #692 

Effectivement, ce n'est pas forcément la peine de mettre à jour Font Awesome à la version 5 : vu l'usage qu'on en fait, je crois qu'on peut rester sur la version 4.7.

J'en ai profité pour ajouter une liste de toutes les icônes qu'on utilise actuellement dans le Storybook (et au passage en corriger une qui était utilsée mais qui n'existe pas)