### PR TITLE
Webpack build on push so we can use it on deploy

### DIFF
--- a/.github/workflows/webpack-build.yml
+++ b/.github/workflows/webpack-build.yml
@@ -1,0 +1,42 @@
+name: Build front bundles
+on: [push]
+
+jobs:
+  webpack:
+    name: Webpack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.babel-cache
+          key: babel-${{ hashFiles('agir/**/*.js') }}
+          restore-keys: |
+            babel-${{ hashFiles('agir/**/*.js') }}
+            babel-
+
+      - name: Install node dependencies
+        run: npm ci
+
+      - name: Build bundles
+        run: npm run build
+        env:
+          BABEL_CACHE_DIRECTORY: ~/.babel-cache
+          WEBPUSH_PUBLIC_KEY: "dummy"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: assets-${{ github.sha }}
+          path: assets/

--- a/.github/workflows/webpack-build.yml
+++ b/.github/workflows/webpack-build.yml
@@ -30,13 +30,21 @@ jobs:
       - name: Install node dependencies
         run: npm ci
 
-      - name: Build bundles
+      - name: Build staging bundles
         run: npm run build
+        if: ${{ github.ref != 'refs/heads/production'}}
         env:
-          BABEL_CACHE_DIRECTORY: ~/.babel-cache
-          WEBPUSH_PUBLIC_KEY: "dummy"
+          WEBPUSH_PUBLIC_KEY: "${{ secrets.WEBPUSH_PUBLIC_KEY }}"
+          SENTRY_ENV: "staging"
+
+      - name: Build production bundles
+        run: npm run build
+        if: ${{ github.ref == 'refs/heads/production'}}
+        env:
+          WEBPUSH_PUBLIC_KEY: "${{ secrets.WEBPUSH_PUBLIC_KEY }}"
+          SENTRY_ENV: "production"
 
       - uses: actions/upload-artifact@v2
         with:
-          name: assets-${{ github.sha }}
+          name: assets
           path: assets/


### PR DESCRIPTION
- chore: build artifacts in gh actions
- feat: different build for production and staging
