### PR TITLE
Various group follower membership type style/wording fixes

### DIFF
--- a/agir/front/components/formComponents/MessageModal/EventStep.js
+++ b/agir/front/components/formComponents/MessageModal/EventStep.js
@@ -190,9 +190,9 @@ const EventStep = (props) => {
       {hasEmailWarning && (
         <StyledWarning>
           <span>
-            Tous vos membres <strong>recevront un e-mail</strong> avec le
-            contenu de votre message et{" "}
-            <strong>pourront y répondre&nbsp;!</strong>
+            Les membres et abonné·es de votre groupe
+            <strong>recevront un e-mail</strong> avec le contenu de votre
+            message et <strong>pourront y répondre&nbsp;!</strong>
           </span>
           <span>
             (Il ne recevront pas d’e-mails pour chaque commentaire ou

--- a/agir/front/components/formComponents/MessageModal/GroupStep.js
+++ b/agir/front/components/formComponents/MessageModal/GroupStep.js
@@ -128,8 +128,9 @@ const GroupStep = (props) => {
       <h4>À qui s'adresse ce message&nbsp;?</h4>
       <StyledWarning>
         <span>
-          Tous vos membres <strong>recevront un e-mail</strong> avec le contenu
-          de votre message et <strong>pourront y répondre !</strong>
+          Les membres et abonné·es de votre groupe
+          <strong>recevront un e-mail</strong> avec le contenu de votre message
+          et <strong>pourront y répondre !</strong>
         </span>
       </StyledWarning>
       {groups.map((group) => (

--- a/agir/front/components/mockData/group.json
+++ b/agir/front/components/mockData/group.json
@@ -59,7 +59,7 @@
   ],
   "facts": {
     "eventCount": 5,
-    "memberCount": 12,
+    "activeMemberCount": 12,
     "isCertified": true,
     "creationDate": "2021-01-08 00:00:00",
     "lastActivityDate": "2021-01-05 00:00:00"

--- a/agir/groups/components/groupPage/GroupFacts.js
+++ b/agir/groups/components/groupPage/GroupFacts.js
@@ -45,7 +45,7 @@ const GroupFacts = (props) => {
 
   const {
     eventCount,
-    memberCount,
+    activeMemberCount,
     isCertified,
     creationDate,
     lastActivityDate,
@@ -62,11 +62,12 @@ const GroupFacts = (props) => {
             </span>
           </li>
         )}
-        {!!memberCount && (
+        {!!activeMemberCount && (
           <li>
             <FeatherIcon name="users" small inline />
             <span>
-              {memberCount} membre{memberCount > 1 && "s"}
+              {activeMemberCount}{" "}
+              {activeMemberCount > 1 ? "membres actifs" : "membre actif"}
             </span>
           </li>
         )}
@@ -102,7 +103,7 @@ const GroupFacts = (props) => {
 GroupFacts.propTypes = {
   facts: PropTypes.shape({
     eventCount: PropTypes.number,
-    memberCount: PropTypes.number,
+    activeMemberCount: PropTypes.number,
     isCertified: PropTypes.bool,
     creationDate: PropTypes.string,
     lastActivityDate: PropTypes.string,

--- a/agir/groups/components/groupPage/GroupFacts.stories.js
+++ b/agir/groups/components/groupPage/GroupFacts.stories.js
@@ -26,7 +26,7 @@ const Template = (args) => {
 export const Default = Template.bind({});
 Default.args = {
   eventCount: 5,
-  memberCount: 12,
+  activeMemberCount: 12,
   isCertified: true,
   creationDate: "2021-01-08 00:00:00",
   lastActivityDate: "2021-01-05 00:00:00",

--- a/agir/groups/components/groupPage/GroupSettings/GroupMemberPage/ConfirmPanel.js
+++ b/agir/groups/components/groupPage/GroupSettings/GroupMemberPage/ConfirmPanel.js
@@ -2,13 +2,14 @@ import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
 
-import BackButton from "@agir/front/genericComponents/ObjectManagement/BackButton.js";
+import BackButton from "@agir/front/genericComponents/ObjectManagement/BackButton";
 import Button from "@agir/front/genericComponents/Button";
-import Spacer from "@agir/front/genericComponents/Spacer.js";
+import Spacer from "@agir/front/genericComponents/Spacer";
 
-import { StyledTitle } from "@agir/groups/groupPage/GroupSettings/styledComponents.js";
+import { StyledTitle } from "@agir/groups/groupPage/GroupSettings/styledComponents";
 
 import { MEMBERSHIP_TYPES } from "@agir/groups/utils/group";
+import { getGenderedWord } from "@agir/lib/utils/display";
 
 const StyledContent = styled.div`
   p {
@@ -61,8 +62,14 @@ const ConfirmPanel = (props) => {
               votre groupe.
             </p>
             <p>
-              Il ne recevra plus les messages postés sur Action Populaire que
-              vous destinez aux membres actifs.
+              {getGenderedWord(
+                selectedMember?.gender,
+                "Ce membre",
+                "Elle",
+                "Il"
+              )}{" "}
+              ne recevra plus les messages postés sur Action Populaire que vous
+              destinez aux membres actifs.
             </p>
             <p>
               {selectedMember?.displayName} restera abonné·e à votre groupe.

--- a/agir/groups/components/groupPage/GroupSettings/GroupMemberPage/MainPanel.js
+++ b/agir/groups/components/groupPage/GroupSettings/GroupMemberPage/MainPanel.js
@@ -52,18 +52,18 @@ const GroupMemberMainPanel = (props) => {
         members={activeMembers}
         onChangeMembershipType={onChangeMembershipType}
       />
+      <Spacer size="2.5rem" />
+      <StyledTitle>
+        {followers.length}&nbsp;
+        {followers.length === 1 ? "Abonné·e" : "Abonné·es"}
+      </StyledTitle>
+      <p style={{ color: style.black700, margin: 0 }}>
+        Toutes les personnes intéressées par votre groupe. Vous pouvez passer un
+        membre actif en abonné·e.
+      </p>
+      <Spacer size="1rem" />
       {followers.length > 0 ? (
         <>
-          <Spacer size="2.5rem" />
-          <StyledTitle>
-            {followers.length}&nbsp;
-            {followers.length > 1 ? "Abonné·es" : "Abonné·e"}
-          </StyledTitle>
-          <p style={{ color: style.black700, margin: 0 }}>
-            Toutes les personnes intéressées par votre groupe. Vous pouvez
-            passer un membre actif en abonné·e.
-          </p>
-          <Spacer size="1rem" />
           <ShareLink
             label="Copier les e-mails des abonné·es"
             color="primary"
@@ -76,7 +76,35 @@ const GroupMemberMainPanel = (props) => {
             onChangeMembershipType={onChangeMembershipType}
           />
         </>
-      ) : null}
+      ) : (
+        <p
+          style={{
+            padding: "1.5rem",
+            boxShadow: style.cardShadow,
+            borderRadius: style.borderRadius,
+          }}
+        >
+          Votre groupe n'a pas encore d'abonné·es.
+          <br />
+          <br />
+          <strong style={{ fontWeight: 600 }}>
+            Vous pouvez passer un membre qui n'est plus actif sur le groupe en
+            abonné
+          </strong>
+          , pour qu'il ne compte pas dans votre nombre de membres actifs. Il ne
+          recevra plus certains messages destinés aux membres actifs.
+          <br />
+          <br />
+          N'importe quel membre d'Action Populaire peut suivre votre groupe en
+          cliquant sur le bouton "Suivre" sur la page de votre groupe.
+          <br />
+          <br />
+          Il n'y a pas de limite de nombre d'abonné·es&nbsp;:{" "}
+          <strong style={{ fontWeight: 600 }}>
+            essayez d'en avoir le plus possible&nbsp;!
+          </strong>
+        </p>
+      )}
       <Spacer size="2.5rem" />
       {routes?.membershipTransfer && (
         <a

--- a/agir/groups/components/groupPage/GroupUserActions/AnonymousActions.js
+++ b/agir/groups/components/groupPage/GroupUserActions/AnonymousActions.js
@@ -43,7 +43,7 @@ const AnonymousActions = () => {
           next: location.pathname,
         }}
       >
-        <RawFeatherIcon name="user-plus" width="1.5rem" height="1.5rem" />
+        <RawFeatherIcon name="plus" width="1.5rem" height="1.5rem" />
         <Spacer size="10px" />
         Rejoindre
       </Button>
@@ -56,7 +56,7 @@ const AnonymousActions = () => {
           next: location.pathname,
         }}
       >
-        <RawFeatherIcon name="plus" width="1.5rem" height="1.5rem" />
+        <RawFeatherIcon name="rss" width="1.5rem" height="1.5rem" />
         <Spacer size="10px" />
         Suivre
       </Button>

--- a/agir/groups/components/groupPage/GroupUserActions/FollowerActions.js
+++ b/agir/groups/components/groupPage/GroupUserActions/FollowerActions.js
@@ -59,7 +59,7 @@ const FollowerActions = ({ onJoin, onQuit }) => {
         </ResponsiveLayout>
       </div>
       <Button $block onClick={onJoin}>
-        <RawFeatherIcon name="user-plus" width="1.5rem" height="1.5rem" />
+        <RawFeatherIcon name="plus" width="1.5rem" height="1.5rem" />
         <Spacer size="10px" />
         Rejoindre
       </Button>

--- a/agir/groups/components/groupPage/GroupUserActions/NonMemberActions.js
+++ b/agir/groups/components/groupPage/GroupUserActions/NonMemberActions.js
@@ -40,12 +40,12 @@ const NonMemberActions = (props) => {
         disabled={isLoading}
         onClick={onJoin}
       >
-        <RawFeatherIcon name="user-plus" width="1.5rem" height="1.5rem" />
+        <RawFeatherIcon name="plus" width="1.5rem" height="1.5rem" />
         <Spacer size="10px" />
         Rejoindre
       </Button>
       <Button type="button" disabled={isLoading} onClick={onFollow}>
-        <RawFeatherIcon name="plus" width="1.5rem" height="1.5rem" />
+        <RawFeatherIcon name="rss" width="1.5rem" height="1.5rem" />
         <Spacer size="10px" />
         Suivre
       </Button>

--- a/agir/groups/components/groupPage/GroupUserActions/QuitGroupDialog.js
+++ b/agir/groups/components/groupPage/GroupUserActions/QuitGroupDialog.js
@@ -78,22 +78,29 @@ const QuitGroupButton = (props) => {
     >
       <StyledDialog>
         <main>
-          <h4>Quitter le groupe</h4>
+          {isActiveMember ? (
+            <h4>Quitter le groupe {groupName}&nbsp;?</h4>
+          ) : (
+            <h4>Ne plus suivre le groupe {groupName}&nbsp;?</h4>
+          )}
           {isActiveMember ? (
             <p>
-              Souhaitez-vous réellement quitter <strong>{groupName}</strong>
-              &nbsp;?
+              Vous ne serez plus considéré·e comme membre actif de votre groupe.
+              <br />
+              Vous ne recevez plus les messages postés sur Action Populaire
+              destinés aux membres actifs.
             </p>
           ) : (
             <p>
-              Souhaitez-vous réellement arretêr de suivre{" "}
-              <strong>{groupName}</strong>&nbsp;?
+              Vous ne recevrez plus les actualités de ce groupe.
+              <br />
+              Vous pouvez suivre ce groupe à nouveau à tout moment.
             </p>
           )}
         </main>
         <footer>
           <Button color="danger" onClick={onConfirm} disabled={isLoading}>
-            {isActiveMember ? "Quitter le groupe" : "Arrêter d'être abonné·e"}
+            {isActiveMember ? "Quitter le groupe" : "Ne plus suivre"}
           </Button>
           <Button color="default" onClick={onDismiss} disabled={isLoading}>
             Annuler

--- a/agir/groups/models.py
+++ b/agir/groups/models.py
@@ -170,6 +170,12 @@ class SupportGroup(
         return Membership.objects.filter(supportgroup=self).count()
 
     @property
+    def active_members_count(self):
+        return Membership.objects.filter(
+            membership_type__gte=Membership.MEMBERSHIP_TYPE_MEMBER, supportgroup=self
+        ).count()
+
+    @property
     def is_full(self):
         return False
         # (Temporarily disabled)

--- a/agir/groups/serializers.py
+++ b/agir/groups/serializers.py
@@ -72,9 +72,7 @@ class SupportGroupSerializer(FlexibleFieldsMixin, serializers.Serializer):
     url = serializers.HyperlinkedIdentityField(view_name="view_group", read_only=True)
 
     eventCount = serializers.ReadOnlyField(source="events_count", read_only=True)
-    membersCount = serializers.SerializerMethodField(
-        source="members_count", read_only=True
-    )
+    membersCount = serializers.SerializerMethodField(read_only=True)
     isMember = serializers.SerializerMethodField(read_only=True)
     isActiveMember = serializers.SerializerMethodField(read_only=True,)
     isManager = serializers.SerializerMethodField(read_only=True)
@@ -231,7 +229,7 @@ class SupportGroupDetailSerializer(FlexibleFieldsMixin, serializers.Serializer):
 
     def get_facts(self, obj):
         facts = {
-            "memberCount": obj.members_count,
+            "activeMemberCount": obj.active_members_count,
             "eventCount": obj.events_count,
             "creationDate": obj.created,
             "isCertified": obj.is_certified,


### PR DESCRIPTION
Group settings:
- Always display follower section even if the group has no follower
- Use member gender in the membership type change confirm modal text

Group page:
- Update follower/active member quit group dialog wording
- Update follow and join group button icons
- Display only the active member count in the group facts section

Messages:
- Update message modal wording to inform the sender that all the group
  members AND followers will receive its message