### PR TITLE
Attempt to fix `/api/session/` preloading

### DIFF
--- a/agir/front/components/allPages/SWRContext.js
+++ b/agir/front/components/allPages/SWRContext.js
@@ -5,6 +5,13 @@ import { SWRConfig } from "swr";
 import axios from "@agir/lib/utils/axios";
 
 const fetcher = async (url) => {
+  if (url === "/api/session/") {
+    const res = await fetch(url, {
+      mode: "no-cors",
+      headers: { Accept: "*/*" },
+    });
+    return res.json();
+  }
   const res = await axios.get(url);
   return res.data;
 };

--- a/agir/front/templates/front/react_view.html
+++ b/agir/front/templates/front/react_view.html
@@ -1,7 +1,7 @@
 {% extends "front/base_layout.html" %}
 
 {% block additional_headers %}
-<link rel="preload" href="{% url "api_session" %}" as="fetch" crossorigin="anonymous">
+<link rel="preload" href="{% url "api_session" %}" as="fetch" type="application/json">
 {% endblock %}
 
 {% block whole_page %}


### PR DESCRIPTION
**Problem:**
In order to `<link rel="preload">` to work, the same endpoint requests must have the exactly same headers (cf. https://blog.keul.it/link-preload-a-walkthrough/). Apparently this is not the case today (a warning is visible in the Chrome console `A preload for 'https://actionpopulaire.fr/api/session/' is found, but is not used because the request headers do not match.`)

**Possible solution :**
Update SWR fetcher to allow session API calls to exactly match the preload link headers.