### PR TITLE
Fix `/api/session/` preloading (attempt no2)

### DIFF
--- a/agir/front/components/allPages/SWRContext.js
+++ b/agir/front/components/allPages/SWRContext.js
@@ -7,8 +7,9 @@ import axios from "@agir/lib/utils/axios";
 const fetcher = async (url) => {
   if (url === "/api/session/") {
     const res = await fetch(url, {
+      method: "GET",
+      credentials: "include",
       mode: "no-cors",
-      headers: { Accept: "*/*" },
     });
     return res.json();
   }

--- a/agir/front/templates/front/react_view.html
+++ b/agir/front/templates/front/react_view.html
@@ -1,7 +1,7 @@
 {% extends "front/base_layout.html" %}
 
 {% block additional_headers %}
-<link rel="preload" href="{% url "api_session" %}" as="fetch" type="application/json">
+<link rel="preload" href="{% url "api_session" %}" as="fetch" type="application/json"></link>
 {% endblock %}
 
 {% block whole_page %}


### PR DESCRIPTION
Cette fois on dirait que ça fonctionne sur Chrome aussi