### PR TITLE
Attempt to smooth out the app first page load

### DIFF
--- a/agir/events/components/agendaPage/AgendaPage.js
+++ b/agir/events/components/agendaPage/AgendaPage.js
@@ -15,7 +15,6 @@ import ConnectivityWarning from "@agir/front/app/ConnectivityWarning";
 import Layout from "@agir/front/dashboardComponents/Layout";
 import TellMorePage from "@agir/front/authentication/Connexion/TellMore/TellMorePage";
 import TopBar from "@agir/front/allPages/TopBar/TopBar";
-import { useLocation } from "react-router-dom";
 
 const StyledWrapper = styled.div`
   padding-top: 72px;
@@ -27,7 +26,6 @@ const StyledWrapper = styled.div`
 
 const AgendaPage = (props) => {
   const isSessionLoaded = useSelector(getIsSessionLoaded);
-  const path = useLocation().pathname;
 
   const [isBannerDownload] = useDownloadBanner();
 
@@ -37,7 +35,7 @@ const AgendaPage = (props) => {
 
   return (
     <>
-      <TopBar path={path} />
+      <TopBar />
       <ConnectivityWarning hasTopBar />
       <TellMorePage />
 

--- a/agir/front/components/allPages/TopBar/DesktopNavBar/DesktopNavBar.js
+++ b/agir/front/components/allPages/TopBar/DesktopNavBar/DesktopNavBar.js
@@ -13,7 +13,11 @@ import SearchBar from "./SearchBar";
 import AdminLink from "./AdminLink";
 
 import { useSelector } from "@agir/front/globalContext/GlobalContext";
-import { getAdminLink, getUser } from "@agir/front/globalContext/reducers";
+import {
+  getAdminLink,
+  getUser,
+  getIsSessionLoaded,
+} from "@agir/front/globalContext/reducers";
 import { useUnreadActivityCount } from "@agir/activity/common/hooks";
 import { useUnreadMessageCount } from "@agir/msgs/common/hooks";
 
@@ -50,8 +54,14 @@ const StyledBar = styled.div`
 `;
 
 export const DesktopNavBar = (props) => {
-  const { user, path, unreadMessageCount, unreadActivityCount, adminLink } =
-    props;
+  const {
+    isLoading,
+    user,
+    path,
+    unreadMessageCount,
+    unreadActivityCount,
+    adminLink,
+  } = props;
 
   const createEventLabel = useResponsiveMemo(
     "Créer",
@@ -66,7 +76,7 @@ export const DesktopNavBar = (props) => {
         <LogoLink route="events">
           <LogoAP height={56} width={149} />
         </LogoLink>
-        {!!user && (
+        {!isLoading && !!user && (
           <>
             <Button
               small
@@ -85,6 +95,7 @@ export const DesktopNavBar = (props) => {
         </div>
         <Spacer size="1rem" />
         <RightLinks
+          isLoading={isLoading}
           user={user}
           path={path}
           unreadMessageCount={unreadMessageCount}
@@ -95,6 +106,7 @@ export const DesktopNavBar = (props) => {
   );
 };
 DesktopNavBar.propTypes = {
+  isLoading: PropTypes.bool,
   user: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
   path: PropTypes.string,
   unreadMessageCount: PropTypes.number,
@@ -105,12 +117,14 @@ DesktopNavBar.propTypes = {
 const ConnectedDesktopNavBar = (props) => {
   const adminLink = useSelector(getAdminLink);
   const user = useSelector(getUser);
+  const isSessionLoaded = useSelector(getIsSessionLoaded);
   const unreadMessageCount = useUnreadMessageCount();
   const unreadActivityCount = useUnreadActivityCount();
 
   return (
     <DesktopNavBar
       {...props}
+      isLoading={!isSessionLoaded}
       user={user}
       unreadMessageCount={unreadMessageCount}
       unreadActivityCount={unreadActivityCount}

--- a/agir/front/components/allPages/TopBar/DesktopNavBar/DesktopNavBar.stories.js
+++ b/agir/front/components/allPages/TopBar/DesktopNavBar/DesktopNavBar.stories.js
@@ -32,6 +32,7 @@ const Template = (args, { globals }) => (
 
 export const Default = Template.bind({});
 Default.args = {
+  isLoading: false,
   path: "/",
   unreadMessageCount: 3,
   unreadActivityCount: 10,

--- a/agir/front/components/allPages/TopBar/DesktopNavBar/RightLinks.js
+++ b/agir/front/components/allPages/TopBar/DesktopNavBar/RightLinks.js
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import Avatar from "@agir/front/genericComponents/Avatar";
 import FeatherIcon from "@agir/front/genericComponents/FeatherIcon";
 import Link from "@agir/front/app/Link";
+import PageFadeIn from "@agir/front/genericComponents/PageFadeIn";
 import Popin from "@agir/front/genericComponents/Popin";
 import Spacer from "@agir/front/genericComponents/Spacer";
 
@@ -93,7 +94,7 @@ const IconLink = styled(Link)`
     }
   }
 `;
-const StyledWrapper = styled.div`
+const StyledWrapper = styled(PageFadeIn)`
   height: 100%;
   display: flex;
   margin-left: auto;
@@ -101,72 +102,78 @@ const StyledWrapper = styled.div`
 `;
 
 const RightLinks = (props) => {
-  const { user, path, unreadActivityCount, unreadMessageCount } = props;
+  const { isLoading, user, path, unreadActivityCount, unreadMessageCount } =
+    props;
 
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
-
-  if (!user) {
-    return (
-      <StyledWrapper>
-        <StyledLink route="help">Aide</StyledLink>
-        <Spacer size="1.5rem" />
-        <StyledLink route="login">Connexion</StyledLink>
-        <Spacer size="1.5rem" />
-        <StyledLink route="signup">Inscription</StyledLink>
-      </StyledWrapper>
-    );
-  }
 
   const openUserMenu = () => setIsUserMenuOpen(true);
   const closeUserMenu = () => setIsUserMenuOpen(false);
 
   return (
-    <StyledWrapper style={{ position: "relative" }}>
-      <Popin
-        isOpen={isUserMenuOpen}
-        onDismiss={closeUserMenu}
-        shouldDismissOnClick
-        position="bottom-right"
-      >
-        <UserMenu user={user} />
-      </Popin>
-      <IconLink route="events" $active={routeConfig.events.match(path)}>
-        <FeatherIcon name="home" />
-        <span>Accueil</span>
-      </IconLink>
-      <IconLink route="activities" $active={routeConfig.activities.match(path)}>
-        <FeatherIcon name="bell" />
-        <span>Notifications</span>
-        {unreadActivityCount > 0 && (
-          <small style={{ right: 30 }}>
-            {Math.min(unreadActivityCount, 99)}
-          </small>
-        )}
-      </IconLink>
-      <IconLink route="messages" $active={routeConfig.messages.match(path)}>
-        <FeatherIcon name="mail" />
-        <span>Messages</span>
-        {unreadMessageCount > 0 && (
-          <small>{Math.min(unreadMessageCount, 99)}</small>
-        )}
-      </IconLink>
-      <IconLink route="tools" $active={routeConfig.tools.match(path)}>
-        <FeatherIcon name="flag" />
-        <span>Outils</span>
-      </IconLink>
-      <IconLink as="button" onClick={openUserMenu}>
-        <Avatar
-          displayName={user.displayName}
-          image={user.image}
-          style={{ width: "28px", height: "28px", marginTop: 0 }}
-        />
-        <span>{user.displayName}</span>
-      </IconLink>
+    <StyledWrapper ready={!isLoading} style={{ position: "relative" }}>
+      {!user ? (
+        <>
+          <StyledLink route="help">Aide</StyledLink>
+          <Spacer size="1.5rem" />
+          <StyledLink route="login">Connexion</StyledLink>
+          <Spacer size="1.5rem" />
+          <StyledLink route="signup">Inscription</StyledLink>
+        </>
+      ) : (
+        <>
+          {" "}
+          <Popin
+            isOpen={isUserMenuOpen}
+            onDismiss={closeUserMenu}
+            shouldDismissOnClick
+            position="bottom-right"
+          >
+            <UserMenu user={user} />
+          </Popin>
+          <IconLink route="events" $active={routeConfig.events.match(path)}>
+            <FeatherIcon name="home" />
+            <span>Accueil</span>
+          </IconLink>
+          <IconLink
+            route="activities"
+            $active={routeConfig.activities.match(path)}
+          >
+            <FeatherIcon name="bell" />
+            <span>Notifications</span>
+            {unreadActivityCount > 0 && (
+              <small style={{ right: 30 }}>
+                {Math.min(unreadActivityCount, 99)}
+              </small>
+            )}
+          </IconLink>
+          <IconLink route="messages" $active={routeConfig.messages.match(path)}>
+            <FeatherIcon name="mail" />
+            <span>Messages</span>
+            {unreadMessageCount > 0 && (
+              <small>{Math.min(unreadMessageCount, 99)}</small>
+            )}
+          </IconLink>
+          <IconLink route="tools" $active={routeConfig.tools.match(path)}>
+            <FeatherIcon name="flag" />
+            <span>Outils</span>
+          </IconLink>
+          <IconLink as="button" onClick={openUserMenu}>
+            <Avatar
+              displayName={user.displayName}
+              image={user.image}
+              style={{ width: "28px", height: "28px", marginTop: 0 }}
+            />
+            <span>{user.displayName}</span>
+          </IconLink>
+        </>
+      )}
     </StyledWrapper>
   );
 };
 
 RightLinks.propTypes = {
+  isLoading: PropTypes.bool,
   user: PropTypes.oneOfType([
     PropTypes.shape({
       displayName: PropTypes.string,

--- a/agir/front/components/allPages/TopBar/MobileNavBar/DashboardPageBar.js
+++ b/agir/front/components/allPages/TopBar/MobileNavBar/DashboardPageBar.js
@@ -11,7 +11,7 @@ import RightLink from "./RightLink";
 import StyledBar, { IconLink } from "./StyledBar";
 
 export const DashboardPageBar = (props) => {
-  const { user, settingsLink } = props;
+  const { isLoading, user, settingsLink } = props;
   return (
     <StyledBar>
       <IconLink route="search">
@@ -22,13 +22,16 @@ export const DashboardPageBar = (props) => {
           <LogoAP small style={{ height: "36px", width: "auto" }} />
         </Link>
       </h1>
-      <RightLink user={user} settingsLink={settingsLink} />
+      <RightLink
+        isLoading={isLoading}
+        user={user}
+        settingsLink={settingsLink}
+      />
     </StyledBar>
   );
 };
 DashboardPageBar.propTypes = {
-  title: PropTypes.string,
-  backLink: PropTypes.object,
+  isLoading: PropTypes.bool,
   settingsLink: PropTypes.object,
   user: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
 };

--- a/agir/front/components/allPages/TopBar/MobileNavBar/DashboardPageBar.stories.js
+++ b/agir/front/components/allPages/TopBar/MobileNavBar/DashboardPageBar.stories.js
@@ -32,7 +32,10 @@ const Template = (args, { globals }) => {
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  isLoading: false,
+  settingsLink: null,
+};
 
 export const WithSettingsLink = Template.bind({});
 WithSettingsLink.args = {

--- a/agir/front/components/allPages/TopBar/MobileNavBar/MobileNavBar.js
+++ b/agir/front/components/allPages/TopBar/MobileNavBar/MobileNavBar.js
@@ -4,6 +4,7 @@ import React, { useMemo } from "react";
 import { routeConfig } from "@agir/front/app/routes.config";
 import { useSelector } from "@agir/front/globalContext/GlobalContext";
 import {
+  getIsSessionLoaded,
   getUser,
   getPageTitle,
   getBackLink,
@@ -16,6 +17,7 @@ import SecondaryPageBar from "./SecondaryPageBar";
 const MobileNavBar = (props) => {
   const { path } = props;
 
+  const isSessionLoaded = useSelector(getIsSessionLoaded);
   const user = useSelector(getUser);
   const pageTitle = useSelector(getPageTitle);
   const backLink = useSelector(getBackLink);
@@ -29,13 +31,18 @@ const MobileNavBar = (props) => {
 
   return isSecondary ? (
     <SecondaryPageBar
+      isLoading={!isSessionLoaded}
       backLink={backLink}
       settingsLink={user ? settingsLink : null}
       title={pageTitle || currentRoute.label}
       user={user}
     />
   ) : (
-    <DashboardPageBar settingsLink={user ? settingsLink : null} user={user} />
+    <DashboardPageBar
+      isLoading={!isSessionLoaded}
+      settingsLink={user ? settingsLink : null}
+      user={user}
+    />
   );
 };
 

--- a/agir/front/components/allPages/TopBar/MobileNavBar/RightLink.js
+++ b/agir/front/components/allPages/TopBar/MobileNavBar/RightLink.js
@@ -4,13 +4,18 @@ import React, { useState } from "react";
 import Avatar from "@agir/front/genericComponents/Avatar";
 import BottomSheet from "@agir/front/genericComponents/BottomSheet";
 import { RawFeatherIcon } from "@agir/front/genericComponents/FeatherIcon";
+import Spacer from "@agir/front/genericComponents/Spacer";
 
 import { IconLink } from "./StyledBar";
 import UserMenu from "../UserMenu";
 
 export const RightLink = (props) => {
-  const { user, settingsLink } = props;
+  const { isLoading, user, settingsLink } = props;
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+
+  if (isLoading) {
+    return <IconLink as={Spacer} size="2rem" />;
+  }
 
   if (!user) {
     return (
@@ -63,6 +68,7 @@ export const RightLink = (props) => {
 };
 
 RightLink.propTypes = {
+  isLoading: PropTypes.bool,
   user: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
   settingsLink: PropTypes.object,
 };

--- a/agir/front/components/allPages/TopBar/MobileNavBar/SecondaryPageBar.js
+++ b/agir/front/components/allPages/TopBar/MobileNavBar/SecondaryPageBar.js
@@ -15,7 +15,7 @@ const defaultBackLink = {
 };
 
 const SecondaryPageBar = (props) => {
-  const { title, user, settingsLink } = props;
+  const { isLoading, title, user, settingsLink } = props;
   const backLink = props.backLink || defaultBackLink;
   return (
     <StyledBar>
@@ -29,12 +29,17 @@ const SecondaryPageBar = (props) => {
         <RawFeatherIcon name="arrow-left" width="1.5rem" height="1.5rem" />
       </IconLink>
       <h2>{title}</h2>
-      <RightLink user={user} settingsLink={settingsLink} />
+      <RightLink
+        isLoading={isLoading}
+        user={user}
+        settingsLink={settingsLink}
+      />
     </StyledBar>
   );
 };
 
 SecondaryPageBar.propTypes = {
+  isLoading: PropTypes.bool,
   title: PropTypes.string,
   backLink: PropTypes.object,
   settingsLink: PropTypes.object,

--- a/agir/front/components/allPages/TopBar/MobileNavBar/SecondaryPageBar.stories.js
+++ b/agir/front/components/allPages/TopBar/MobileNavBar/SecondaryPageBar.stories.js
@@ -34,6 +34,7 @@ const Template = (args, { globals }) => {
 
 export const Default = Template.bind({});
 Default.args = {
+  isLoading: false,
   title: "Page title !",
   backLink: {
     to: "/",

--- a/agir/front/components/allPages/TopBar/MobileNavBar/StyledBar.js
+++ b/agir/front/components/allPages/TopBar/MobileNavBar/StyledBar.js
@@ -46,7 +46,8 @@ const StyledBar = styled.div`
 
   ${IconLink} {
     display: flex;
-    height: 100%;
+    height: 2rem;
+    width: 2rem;
     align-items: center;
     color: ${(props) => props.theme.black1000};
     line-height: 0;

--- a/agir/front/components/allPages/TopBar/TopBar.js
+++ b/agir/front/components/allPages/TopBar/TopBar.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
+import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 
 import DownloadApp from "@agir/front/genericComponents/DownloadApp";
@@ -15,7 +16,7 @@ const StyledPageHead = styled.div`
   isolation: isolate;
 `;
 
-const TopBar = ({ path, hideBannerDownload }) => {
+export const TopBar = ({ path, hideBannerDownload }) => {
   return (
     <StyledPageHead>
       {!hideBannerDownload && <DownloadApp />}
@@ -28,4 +29,10 @@ TopBar.propTypes = {
   path: PropTypes.string,
   hideBannerDownload: PropTypes.bool,
 };
-export default TopBar;
+
+const RouterTopBar = (props) => {
+  const { pathname } = useLocation();
+  return <TopBar {...props} path={pathname} />;
+};
+
+export default RouterTopBar;

--- a/agir/front/components/app/Page.js
+++ b/agir/front/components/app/Page.js
@@ -4,9 +4,6 @@ import { useHistory, useLocation, useParams } from "react-router-dom";
 import styled from "styled-components";
 
 import style from "@agir/front/genericComponents/_variables.scss";
-import Spacer from "@agir/front/genericComponents/Spacer";
-
-import { useDownloadBanner } from "@agir/front/app/hooks.js";
 import {
   useDispatch,
   useSelector,
@@ -19,10 +16,8 @@ import {
   setPageTitle,
 } from "@agir/front/globalContext/actions";
 
-import ConnectivityWarning from "@agir/front/app/ConnectivityWarning";
 import Layout from "@agir/front/dashboardComponents/Layout";
 import FeedbackButton from "@agir/front/allPages/FeedbackButton";
-import TopBar from "@agir/front/allPages/TopBar/TopBar";
 
 import ErrorBoundary from "./ErrorBoundary";
 import logger from "@agir/lib/utils/logger";
@@ -48,7 +43,7 @@ const Page = (props) => {
 
   const dispatch = useDispatch();
   const isSessionLoaded = useSelector(getIsSessionLoaded);
-  const [isBannerDownload] = useDownloadBanner();
+
   const history = useHistory();
   const routeParams = useParams();
   const { pathname } = useLocation();
@@ -107,13 +102,7 @@ const Page = (props) => {
   if (!routeConfig.hasLayout) {
     return (
       <ErrorBoundary>
-        {!routeConfig.hideTopBar && <TopBar path={pathname} />}
-        {!routeConfig.hideTopBar && isBannerDownload && <Spacer size="80px" />}
-
         <StyledPage $hasTopBar={!routeConfig.hideTopBar}>
-          {!routeConfig.hideConnectivityWarning && (
-            <ConnectivityWarning hasTopBar={!routeConfig.hideTopBar} />
-          )}
           <Suspense fallback={<div />}>
             <Component route={routeConfig} {...routeParams} {...rest} />
             {!routeConfig.hideFeedbackButton && (
@@ -127,12 +116,6 @@ const Page = (props) => {
 
   return (
     <ErrorBoundary>
-      {!routeConfig.hideTopBar && <TopBar path={pathname} />}
-      {!routeConfig.hideTopBar && isBannerDownload && <Spacer size="80px" />}
-      {!routeConfig.hideConnectivityWarning && (
-        <ConnectivityWarning hasTopBar={!routeConfig.hideTopBar} />
-      )}
-
       <StyledPage $hasTopBar={!routeConfig.hideTopBar}>
         <Layout {...(routeConfig.layoutProps || {})} active={routeConfig.id}>
           <Suspense fallback={<div />}>

--- a/agir/front/components/genericComponents/LogoAP.js
+++ b/agir/front/components/genericComponents/LogoAP.js
@@ -11,6 +11,8 @@ const LogoAP = styled.img.attrs(({ small }) => ({
   width: small ? "182" : "149",
   height: small ? "35" : "56",
 }))`
+  font-size: 0;
+  color: transparent;
   height: ${(props) => props.height + "px" || "auto"};
   width: ${(props) => props.width + "px" || "auto"};
   vertical-align: unset;

--- a/agir/front/components/legacyPages/renderLegacyPageComponents.js
+++ b/agir/front/components/legacyPages/renderLegacyPageComponents.js
@@ -6,7 +6,7 @@ import { renderReactComponent } from "@agir/lib/utils/react";
 import GlobalContextProvider from "@agir/front/globalContext/GlobalContext";
 import PushModal from "@agir/front/allPages/PushModal";
 import FeedbackButton from "@agir/front/allPages/FeedbackButton";
-import TopBar from "@agir/front/allPages/TopBar/TopBar";
+import { TopBar } from "@agir/front/allPages/TopBar/TopBar";
 import SWRContext from "@agir/front/allPages/SWRContext";
 
 const renderLegacyPageComponents = () => {


### PR DESCRIPTION
- Separate ProtectedComponent and TopBar mounting
- Allow some of the top bar elements to have a loading state (while the session is loading)
- Remove the app loader only after some authentication state has been determined  for the current page