### PR TITLE
Fix Cleave paste crashing issue (ACTIONPOPULAIRE-FRONT-12H)

### DIFF
--- a/agir/front/components/formComponents/PhoneField.js
+++ b/agir/front/components/formComponents/PhoneField.js
@@ -97,6 +97,9 @@ const PhoneField = forwardRef((props, ref) => {
           name="phone"
           value={value || ""}
           onChange={onChange}
+          onInit={(owner) => {
+            owner.lastInputValue = value || "";
+          }}
         />
       </StyledInput>
       <StyledIcon>

--- a/agir/lib/components/creationForms/steps/ContactStep.js
+++ b/agir/lib/components/creationForms/steps/ContactStep.js
@@ -130,6 +130,9 @@ class ContactStep extends FormStep {
                   name="phone"
                   value={phone || ""}
                   onChange={this.handleInputChange}
+                  onInit={(owner) => {
+                    owner.lastInputValue = phone || "";
+                  }}
                 />
                 {this.showError("phone")}
               </div>


### PR DESCRIPTION
[Un bug de la librairie Cleave JS](https://github.com/nosir/cleave.js/issues/601), cause un crash de la page lorsqu'on essaie de coller dans un champs téléphone un numéro de téléphone en utilisant le bouton droit de la souris et lorsque le champs est vide et n'a jamais été rempli jusque là. 
