### PR TITLE
Page groupe : retours

### DIFF
--- a/agir/front/components/genericComponents/ModalConfirmation.js
+++ b/agir/front/components/genericComponents/ModalConfirmation.js
@@ -10,8 +10,6 @@ import style from "@agir/front/genericComponents/_variables.scss";
 
 const ModalContainer = styled.div`
   background: white;
-  height: 50%;
-  min-height: 365px;
   width: 40%;
   margin: 5% auto;
   display: flex;
@@ -22,8 +20,6 @@ const ModalContainer = styled.div`
 
   @media (max-width: ${style.collapse}px) {
     width: 90%;
-    height: 70%;
-    min-height: 400px;
   }
 `;
 

--- a/agir/front/components/genericComponents/ModalConfirmation.js
+++ b/agir/front/components/genericComponents/ModalConfirmation.js
@@ -4,7 +4,9 @@ import styled from "styled-components";
 
 import Button from "@agir/front/genericComponents/Button";
 import Spacer from "@agir/front/genericComponents/Spacer";
+import { ResponsiveLayout } from "@agir/front/genericComponents/grid";
 
+import BottomSheet from "@agir/front/genericComponents/BottomSheet";
 import Modal from "@agir/front/genericComponents/Modal";
 import style from "@agir/front/genericComponents/_variables.scss";
 
@@ -50,7 +52,16 @@ const ModalConfirmation = (props) => {
   } = props;
 
   return (
-    <Modal shouldShow={shouldShow} onClose={onClose}>
+    <ResponsiveLayout
+      DesktopLayout={Modal}
+      MobileLayout={BottomSheet}
+      shouldShow={shouldShow}
+      isOpen={shouldShow}
+      onClose={onClose}
+      onDismiss={onClose}
+      shouldDismissOnClick
+      noScroll
+    >
       <ModalContainer>
         <ModalContent>
           <h1>{title}</h1>
@@ -75,7 +86,7 @@ const ModalConfirmation = (props) => {
           </Button>
         </ModalContent>
       </ModalContainer>
-    </Modal>
+    </ResponsiveLayout>
   );
 };
 

--- a/agir/front/components/genericComponents/ModalShare.js
+++ b/agir/front/components/genericComponents/ModalShare.js
@@ -12,6 +12,7 @@ import { FaWhatsapp, FaFacebook, FaTelegramPlane } from "react-icons/fa";
 
 const ModalContainer = styled.div`
   background: white;
+  width: 40%;
   width: fit-content;
   margin: 5% auto;
   display: flex;

--- a/agir/front/components/genericComponents/ModalShare.js
+++ b/agir/front/components/genericComponents/ModalShare.js
@@ -12,9 +12,7 @@ import { FaWhatsapp, FaFacebook, FaTelegramPlane } from "react-icons/fa";
 
 const ModalContainer = styled.div`
   background: white;
-  height: 50%;
-  min-height: 365px;
-  width: 40%;
+  width: fit-content;
   margin: 5% auto;
   display: flex;
   align-items: center;
@@ -24,8 +22,6 @@ const ModalContainer = styled.div`
 
   @media (max-width: ${style.collapse}px) {
     width: 90%;
-    height: 70%;
-    min-height: 400px;
   }
 `;
 

--- a/agir/groups/components/groupPage/GroupUserActions/SecondaryActions.js
+++ b/agir/groups/components/groupPage/GroupUserActions/SecondaryActions.js
@@ -21,7 +21,7 @@ const StyledContainer = styled.div`
 
   ${Button} {
     background-color: white;
-    font-size: 12px;
+    font-size: 14px;
     border: none;
     display: inline-flex;
     flex-direction: column;
@@ -40,18 +40,18 @@ const SecondaryActions = ({ routes, ...rest }) => {
       <StyledContainer>
         <a href={`mailto:${rest?.contact.email}`}>
           <Button type="button">
-            <RawFeatherIcon name="mail" width="1rem" height="1rem" />
+            <RawFeatherIcon name="mail" width="1.5rem" height="1.5rem" />
             Contacter
           </Button>
         </a>
         {!!routes?.donations && (
           <Button type="button" link route={routes.donations}>
-            <RawFeatherIcon name="upload" width="1rem" height="1rem" />
+            <RawFeatherIcon name="upload" width="1.5rem" height="1.5rem" />
             Financer
           </Button>
         )}
         <Button type="button" onClick={handleShare}>
-          <RawFeatherIcon name="share-2" width="1rem" height="1rem" />
+          <RawFeatherIcon name="share-2" width="1.5rem" height="1.5rem" />
           Partager
         </Button>
         <ModalShare

--- a/agir/groups/components/groupPage/GroupUserActions/index.js
+++ b/agir/groups/components/groupPage/GroupUserActions/index.js
@@ -208,7 +208,9 @@ const ConnectedUserActions = (props) => {
         description={modalJoinDescription}
         dismissLabel={modalJoinDismiss}
         confirmationLabel={modalJoinConfirm}
-        confirmationUrl={`mailto:${props?.contact?.email}`}
+        confirmationUrl={
+          props?.contact?.email ? `mailto:${props?.contact?.email}` : undefined
+        }
       />
       <ModalConfirmation
         key={2}

--- a/agir/groups/components/groupPage/GroupUserActions/index.js
+++ b/agir/groups/components/groupPage/GroupUserActions/index.js
@@ -207,7 +207,7 @@ const ConnectedUserActions = (props) => {
         description={modalJoinDescription}
         dismissLabel={modalJoinDismiss}
         confirmationLabel={modalJoinConfirm}
-        confirmationUrl="messages"
+        confirmationUrl={`mailto:${props?.contact?.email}`}
       />
       <ModalConfirmation
         key={2}

--- a/agir/groups/components/groupPage/GroupUserActions/index.js
+++ b/agir/groups/components/groupPage/GroupUserActions/index.js
@@ -24,12 +24,13 @@ const StyledContent = styled.div`
   display: flex;
   align-items: flex-start;
   flex-flow: column nowrap;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
 
   @media (max-width: ${style.collapse}px) {
     background-color: white;
     width: 100%;
     padding: 0 1rem 1.5rem;
+    padding-bottom: 0.5rem;
     margin-bottom: 0;
     align-items: center;
     display: ${({ hideOnMobile }) => (hideOnMobile ? "none" : "flex")};


### PR DESCRIPTION
Modale de confirmation : 
- Rendue sous forme de tiroir version mobile avec BottomSheet
- url `mailTo` pour les nouveaux arrivants sur un groupe
- Marges fixées version ordinateur
- Styles des boutons secondaires