### PR TITLE
Allow a person to give personal info consent from a group page

### DIFF
--- a/agir/front/components/genericComponents/BottomSheet.js
+++ b/agir/front/components/genericComponents/BottomSheet.js
@@ -96,8 +96,8 @@ export const BottomSheet = (props) => {
 };
 
 BottomSheet.propTypes = {
-  isOpen: PropTypes.bool.isRequired,
-  onDismiss: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool,
+  onDismiss: PropTypes.func,
   shouldDismissOnClick: PropTypes.bool,
   children: PropTypes.node,
 };

--- a/agir/front/components/genericComponents/ModalConfirmation.js
+++ b/agir/front/components/genericComponents/ModalConfirmation.js
@@ -31,7 +31,7 @@ const ModalContent = styled.div`
   flex-direction: column;
   padding: 1rem;
 
-  h1 {
+  h3 {
     font-size: 1rem;
   }
 
@@ -50,6 +50,7 @@ const ModalConfirmation = (props) => {
     dismissLabel,
     confirmationLabel = "",
     confirmationUrl = "",
+    shouldDismissOnClick = true,
   } = props;
 
   return (
@@ -60,12 +61,12 @@ const ModalConfirmation = (props) => {
       isOpen={shouldShow}
       onClose={onClose}
       onDismiss={onClose}
-      shouldDismissOnClick
+      shouldDismissOnClick={shouldDismissOnClick}
       noScroll
     >
       <ModalContainer>
         <ModalContent>
-          <h1>{title}</h1>
+          <h3>{title}</h3>
           {children}
           <Spacer size="1rem" />
           {!!confirmationUrl && (
@@ -101,6 +102,7 @@ ModalConfirmation.propTypes = {
   dismissLabel: PropTypes.node,
   confirmationLabel: PropTypes.node,
   confirmationUrl: PropTypes.string,
+  shouldDismissOnClick: PropTypes.bool,
 };
 
 export default ModalConfirmation;

--- a/agir/groups/components/api.js
+++ b/agir/groups/components/api.js
@@ -6,6 +6,7 @@ export const ENDPOINT = {
 
   joinGroup: "/api/groupes/:groupPk/rejoindre/",
   followGroup: "/api/groupes/:groupPk/suivre/",
+  updateOwnMembership: "/api/groupes/:groupPk/membre/",
   quitGroup: "/api/groupes/:groupPk/quitter/",
 
   getUpcomingEvents: "/api/groupes/:groupPk/evenements/a-venir/",
@@ -430,6 +431,23 @@ export const searchGroups = async (searchTerms, params = {}) => {
     result.data = response.data;
   } catch (e) {
     result.error = (e.response && e.response.data) || { global: e.message };
+  }
+
+  return result;
+};
+
+export const updateOwnMembership = async (groupPk, data) => {
+  const result = {
+    data: null,
+    error: null,
+  };
+  const url = getGroupEndpoint("updateOwnMembership", { groupPk });
+
+  try {
+    const response = await axios.patch(url, data);
+    result.data = response.data;
+  } catch (e) {
+    result.error = (e.response && e.response.data) || e.message;
   }
 
   return result;

--- a/agir/groups/components/groupPage/GroupUserActions/EditMembershipDialog.js
+++ b/agir/groups/components/groupPage/GroupUserActions/EditMembershipDialog.js
@@ -1,0 +1,74 @@
+import PropTypes from "prop-types";
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import Button from "@agir/front/genericComponents/Button";
+import CheckboxField from "@agir/front/formComponents/CheckboxField";
+import ModalConfirmation from "@agir/front/genericComponents/ModalConfirmation";
+import Spacer from "@agir/front/genericComponents/Spacer";
+import StyledDialog from "./StyledDialog";
+
+const JoinGroupDialog = (props) => {
+  const { shouldShow, isLoading, onUpdate, onClose } = props;
+
+  const [personalInfoConsent, setPersonalInfoConsent] = useState(
+    props?.personalInfoConsent || false
+  );
+
+  const handleCheck = (e) => {
+    setPersonalInfoConsent(e.target.checked);
+  };
+
+  const handleUpdate = () => {
+    onUpdate({ personalInfoConsent });
+  };
+
+  return (
+    <ModalConfirmation
+      shouldShow={shouldShow}
+      onClose={!isLoading ? onClose : undefined}
+      shouldDismissOnClick={false}
+    >
+      <StyledDialog>
+        <header>
+          <h3>Modifier les informations que je partage avec le groupe</h3>
+        </header>
+        <article>
+          <CheckboxField
+            label="Nom public et adresse e-mail (obligatoire)"
+            readOnly
+            disabled
+            value
+          />
+          <CheckboxField
+            label="Coordonées complètes (nom complet, téléphone et adresse)."
+            onChange={handleCheck}
+            disabled={isLoading}
+            value={personalInfoConsent}
+          />
+        </article>
+        <footer>
+          <Button
+            disabled={isLoading}
+            loading={isLoading}
+            onClick={handleUpdate}
+            color="primary"
+            block
+            wrap
+          >
+            Mettre à jour
+          </Button>
+        </footer>
+      </StyledDialog>
+    </ModalConfirmation>
+  );
+};
+
+JoinGroupDialog.propTypes = {
+  shouldShow: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  onUpdate: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default JoinGroupDialog;

--- a/agir/groups/components/groupPage/GroupUserActions/EditMembershipDialog.stories.js
+++ b/agir/groups/components/groupPage/GroupUserActions/EditMembershipDialog.stories.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+import EditMembershipDialog from "./EditMembershipDialog";
+
+export default {
+  component: EditMembershipDialog,
+  title: "Group/GroupUserActions/EditMembershipDialog",
+};
+
+const Template = (args) => <EditMembershipDialog {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  shouldShow: true,
+};
+
+export const Loading = Template.bind({});
+Loading.args = {
+  ...Default.args,
+  personalInfoConsent: true,
+  isLoading: true,
+};

--- a/agir/groups/components/groupPage/GroupUserActions/FollowGroupDialog.js
+++ b/agir/groups/components/groupPage/GroupUserActions/FollowGroupDialog.js
@@ -1,0 +1,34 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import ModalConfirmation from "@agir/front/genericComponents/ModalConfirmation";
+import Spacer from "@agir/front/genericComponents/Spacer";
+import StyledDialog from "./StyledDialog";
+
+const ConnectedUserActions = (props) => {
+  const { shouldShow, onClose, groupName } = props;
+
+  return (
+    <ModalConfirmation shouldShow={shouldShow} onClose={onClose}>
+      <StyledDialog>
+        <header>
+          <h3>Vous suivez {groupName} ! 👋</h3>
+        </header>
+        <article>
+          Vous recevrez l’actualité de ce groupe.
+          <Spacer size="0.5rem" />
+          Vous pouvez le rejoindre en tant que membre pour recevoir les messages
+          destinés aux membres actifs à tout moment.
+        </article>
+      </StyledDialog>
+    </ModalConfirmation>
+  );
+};
+
+ConnectedUserActions.propTypes = {
+  shouldShow: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
+  groupName: PropTypes.string.isRequired,
+};
+
+export default ConnectedUserActions;

--- a/agir/groups/components/groupPage/GroupUserActions/FollowGroupDialog.stories.js
+++ b/agir/groups/components/groupPage/GroupUserActions/FollowGroupDialog.stories.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+import group from "@agir/front/mockData/group.json";
+
+import FollowGroupDialog from "./FollowGroupDialog";
+
+export default {
+  component: FollowGroupDialog,
+  title: "Group/GroupUserActions/FollowGroupDialog",
+};
+
+const Template = (args) => {
+  return <FollowGroupDialog {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  shouldShow: true,
+  groupName: group.name,
+};

--- a/agir/groups/components/groupPage/GroupUserActions/FollowerActions.js
+++ b/agir/groups/components/groupPage/GroupUserActions/FollowerActions.js
@@ -24,7 +24,7 @@ const StyledWrapper = styled.div`
   }
 `;
 
-const FollowerActions = ({ onJoin, onQuit }) => {
+const FollowerActions = ({ isLoading, onJoin, onEdit, onQuit }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const openMenu = useCallback(() => setIsMenuOpen(true), []);
   const closeMenu = useCallback(() => setIsMenuOpen(false), []);
@@ -32,7 +32,7 @@ const FollowerActions = ({ onJoin, onQuit }) => {
   return (
     <StyledWrapper>
       <div style={{ position: "relative" }}>
-        <Button $block onClick={openMenu} color="confirmed">
+        <Button block onClick={openMenu} color="confirmed">
           <RawFeatherIcon name="rss" width="1.5rem" height="1.5rem" />
           <Spacer size="10px" />
           Vous êtes abonné·e
@@ -49,6 +49,13 @@ const FollowerActions = ({ onJoin, onQuit }) => {
         >
           <StyledMenuList>
             <li>
+              <button type="button" onClick={onEdit}>
+                <RawFeatherIcon name="lock" width="1rem" height="1rem" />
+                <Spacer size=".5rem" />
+                Préférences de confidentialité
+              </button>
+            </li>
+            <li>
               <button type="button" onClick={onQuit}>
                 <RawFeatherIcon name="x" width="1rem" height="1rem" />
                 <Spacer size=".5rem" />
@@ -58,7 +65,7 @@ const FollowerActions = ({ onJoin, onQuit }) => {
           </StyledMenuList>
         </ResponsiveLayout>
       </div>
-      <Button $block onClick={onJoin}>
+      <Button block onClick={onJoin} loading={isLoading} disabled={isLoading}>
         <RawFeatherIcon name="plus" width="1.5rem" height="1.5rem" />
         <Spacer size="10px" />
         Rejoindre
@@ -69,7 +76,9 @@ const FollowerActions = ({ onJoin, onQuit }) => {
 
 FollowerActions.propTypes = {
   onJoin: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
   onQuit: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
 };
 
 export default FollowerActions;

--- a/agir/groups/components/groupPage/GroupUserActions/FollowerActions.stories.js
+++ b/agir/groups/components/groupPage/GroupUserActions/FollowerActions.stories.js
@@ -10,4 +10,6 @@ export default {
 const Template = (args) => <FollowerActions {...args} />;
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  isLoading: false,
+};

--- a/agir/groups/components/groupPage/GroupUserActions/JoinGroupDialog.js
+++ b/agir/groups/components/groupPage/GroupUserActions/JoinGroupDialog.js
@@ -1,0 +1,172 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import Button from "@agir/front/genericComponents/Button";
+import ModalConfirmation from "@agir/front/genericComponents/ModalConfirmation";
+import ShareLink from "@agir/front/genericComponents/ShareLink";
+import Spacer from "@agir/front/genericComponents/Spacer";
+import StyledDialog from "./StyledDialog";
+
+export const JoinGroup = (props) => {
+  const {
+    step,
+    isLoading,
+    groupName,
+    groupContact,
+    groupReferents,
+    personName,
+    onJoin,
+    onUpdate,
+    onClose,
+  } = props;
+
+  switch (step) {
+    case 1:
+      return (
+        <StyledDialog>
+          <header>
+            <h3>Rejoindre {groupName}</h3>
+          </header>
+          <article>
+            Les animateur·ices du groupe seront informé·es de votre arrivée et
+            vous pourrez préparer votre venue à votre première action !
+          </article>
+          <footer>
+            <Button
+              disabled={isLoading}
+              loading={isLoading}
+              onClick={onJoin}
+              color="primary"
+              block
+              wrap
+            >
+              Je rejoins&nbsp;!
+            </Button>
+            <Button disabled={isLoading} onClick={onClose} block wrap>
+              Annuler
+            </Button>
+          </footer>
+        </StyledDialog>
+      );
+    case 2: {
+      let referentNames = groupReferents
+        .map((referent, i) => {
+          if (i === 0) {
+            return referent.displayName;
+          }
+          if (i === groupReferents.length - 1) {
+            return " et " + referent.displayName;
+          }
+          return ", " + referent.displayName;
+        })
+        .join("");
+
+      const handleUpdate = () => onUpdate({ personalInfoConsent: true });
+
+      return (
+        <StyledDialog>
+          <header>
+            <h3>Bienvenue dans le groupe, {personName}&nbsp;!&nbsp;👍</h3>
+          </header>
+          <article>
+            <strong>
+              C’est maintenant que tout se joue : faites la rencontre avec{" "}
+              {referentNames} qui animent ce groupe.
+            </strong>
+            <Spacer size=".5rem" />
+            Pour faciliter le contact, partagez vos coordonnées avec eux (nom
+            complet, téléphone et adresse).
+            <Spacer size=".5rem" />
+            Vous pourrez retirer cette autorisation à tout moment.
+          </article>
+          <footer>
+            <Button
+              disabled={isLoading}
+              loading={isLoading}
+              onClick={handleUpdate}
+              block
+              wrap
+            >
+              Partager mes coordonnées avec {referentNames}
+            </Button>
+            <Button disabled={isLoading} onClick={onClose} block wrap>
+              Passer cette étape
+            </Button>
+          </footer>
+        </StyledDialog>
+      );
+    }
+    case 3: {
+      return (
+        <StyledDialog>
+          <header>
+            <h3>Présentez-vous&nbsp;!</h3>
+          </header>
+          <article>
+            <strong>
+              C’est noté, les gestionnaires du groupe pourront vous contacter
+              sur la messagerie d’Action Populaire, par e-mail et par téléphone.
+            </strong>
+            <Spacer size=".5rem" />
+            Envoyez-leur un message pour vous présenter&nbsp;!
+            <Spacer size="1rem" />
+            <ShareLink
+              label="Copier"
+              color="primary"
+              url={groupContact.email}
+              $wrap
+            />
+            <Spacer size=".5rem" />
+          </article>
+          <footer>
+            <Button onClick={onClose} block wrap>
+              Non merci
+            </Button>
+          </footer>
+        </StyledDialog>
+      );
+    }
+    default:
+      return null;
+  }
+};
+
+JoinGroup.propTypes = {
+  step: PropTypes.number.isRequired,
+  isLoading: PropTypes.bool,
+  personName: PropTypes.string.isRequired,
+  groupName: PropTypes.string.isRequired,
+  groupContact: PropTypes.shape({
+    email: PropTypes.string.isRequired,
+  }).isRequired,
+  groupReferents: PropTypes.arrayOf(
+    PropTypes.shape({
+      displayName: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  onJoin: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+const JoinGroupDialog = (props) => {
+  const { step, isLoading, onClose } = props;
+
+  return (
+    <ModalConfirmation
+      shouldShow={step > 0}
+      onClose={!isLoading ? onClose : undefined}
+      shouldDismissOnClick={false}
+    >
+      <JoinGroup {...props} />
+    </ModalConfirmation>
+  );
+};
+
+JoinGroupDialog.propTypes = {
+  step: PropTypes.number.isRequired,
+  isLoading: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default JoinGroupDialog;

--- a/agir/groups/components/groupPage/GroupUserActions/JoinGroupDialog.stories.js
+++ b/agir/groups/components/groupPage/GroupUserActions/JoinGroupDialog.stories.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+import group from "@agir/front/mockData/group.json";
+
+import JoinGroupDialog from "./JoinGroupDialog";
+
+export default {
+  component: JoinGroupDialog,
+  title: "Group/GroupUserActions/JoinGroupDialog",
+};
+
+const Template = (args) => {
+  return <JoinGroupDialog {...args} />;
+};
+
+export const Step1 = Template.bind({});
+Step1.args = {
+  step: 1,
+  isLoading: false,
+  personName: "Jane Doe",
+  groupName: group.name,
+  groupContact: group.contact,
+  groupReferents: group.referents,
+};
+export const Step2 = Template.bind({});
+Step2.args = {
+  ...Step1.args,
+  step: 2,
+};
+export const Step3 = Template.bind({});
+Step3.args = {
+  ...Step1.args,
+  step: 3,
+};

--- a/agir/groups/components/groupPage/GroupUserActions/MemberActions.js
+++ b/agir/groups/components/groupPage/GroupUserActions/MemberActions.js
@@ -16,16 +16,9 @@ const StyledWrapper = styled.div`
   flex-flow: column nowrap;
   gap: 0.5rem;
   position: relative;
-
-  ${Button} {
-    ${"" /* TODO: remove after Button refactoring merge */}
-    width: 100%;
-    margin: 0;
-    justify-content: center;
-  }
 `;
 
-const MemberActions = ({ onQuit }) => {
+const MemberActions = ({ onQuit, onEdit }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const openMenu = useCallback(() => setIsMenuOpen(true), []);
   const closeMenu = useCallback(() => setIsMenuOpen(false), []);
@@ -49,6 +42,13 @@ const MemberActions = ({ onQuit }) => {
       >
         <StyledMenuList>
           <li>
+            <button type="button" onClick={onEdit}>
+              <RawFeatherIcon name="lock" width="1rem" height="1rem" />
+              <Spacer size=".5rem" />
+              Préférences de confidentialité
+            </button>
+          </li>
+          <li>
             <button type="button" onClick={onQuit}>
               <RawFeatherIcon name="x" width="1rem" height="1rem" />
               <Spacer size=".5rem" />
@@ -62,6 +62,7 @@ const MemberActions = ({ onQuit }) => {
 };
 
 MemberActions.propTypes = {
+  onEdit: PropTypes.func.isRequired,
   onQuit: PropTypes.func.isRequired,
 };
 

--- a/agir/groups/components/groupPage/GroupUserActions/NonMemberActions.js
+++ b/agir/groups/components/groupPage/GroupUserActions/NonMemberActions.js
@@ -37,7 +37,12 @@ const NonMemberActions = (props) => {
         <Spacer size="10px" />
         Rejoindre
       </Button>
-      <Button type="button" disabled={isLoading} onClick={onFollow}>
+      <Button
+        type="button"
+        loading={isLoading}
+        disabled={isLoading}
+        onClick={onFollow}
+      >
         <RawFeatherIcon name="rss" width="1.5rem" height="1.5rem" />
         <Spacer size="10px" />
         Suivre

--- a/agir/groups/components/groupPage/GroupUserActions/QuitGroupDialog.js
+++ b/agir/groups/components/groupPage/GroupUserActions/QuitGroupDialog.js
@@ -7,7 +7,7 @@ import ModalConfirmation from "@agir/front/genericComponents/ModalConfirmation";
 import Spacer from "@agir/front/genericComponents/Spacer";
 import StyledDialog from "./StyledDialog";
 
-const JoinGroupDialog = (props) => {
+const QuitGroupDialog = (props) => {
   const { shouldShow, isLoading, isActiveMember, groupName, onQuit, onClose } =
     props;
 
@@ -59,7 +59,7 @@ const JoinGroupDialog = (props) => {
   );
 };
 
-JoinGroupDialog.propTypes = {
+QuitGroupDialog.propTypes = {
   shouldShow: PropTypes.bool,
   isLoading: PropTypes.bool,
   isActiveMember: PropTypes.bool,
@@ -68,4 +68,4 @@ JoinGroupDialog.propTypes = {
   onClose: PropTypes.func.isRequired,
 };
 
-export default JoinGroupDialog;
+export default QuitGroupDialog;

--- a/agir/groups/components/groupPage/GroupUserActions/QuitGroupDialog.js
+++ b/agir/groups/components/groupPage/GroupUserActions/QuitGroupDialog.js
@@ -1,121 +1,71 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
-import style from "@agir/front/genericComponents/_variables.scss";
-
-import { ResponsiveLayout } from "@agir/front/genericComponents/grid";
 import Button from "@agir/front/genericComponents/Button";
-import Modal from "@agir/front/genericComponents/Modal";
-import BottomSheet from "@agir/front/genericComponents/BottomSheet";
+import ModalConfirmation from "@agir/front/genericComponents/ModalConfirmation";
+import Spacer from "@agir/front/genericComponents/Spacer";
+import StyledDialog from "./StyledDialog";
 
-const StyledDialog = styled.div`
-  max-width: 415px;
-  margin: 40px auto;
-  background-color: ${style.white};
-  border-radius: 8px;
-  padding: 1rem;
-
-  @media (max-width: ${style.collapse}px) {
-    margin: 0;
-    border-radius: 0;
-    max-width: 100%;
-  }
-
-  main {
-    h4 {
-      margin-top: 0;
-      margin-bottom: 1rem;
-      font-size: 1rem;
-      font-weight: 600;
-      line-height: 1.5;
-    }
-
-    p {
-      margin: 0;
-      padding: 0;
-      font-size: 0.875rem;
-      line-height: 1.5;
-    }
-  }
-  footer {
-    display: flex;
-    margin-top: 1.5rem;
-    flex-flow: column nowrap;
-
-    ${Button} {
-      flex: 1 1 auto;
-      justify-content: center;
-      transition: opacity 250ms ease-in-out;
-    }
-
-    ${Button} + ${Button} {
-      margin: 0.5rem 0 0;
-    }
-  }
-`;
-
-const QuitGroupButton = (props) => {
-  const {
-    groupName,
-    isActiveMember,
-    shouldShow,
-    isLoading,
-    onDismiss,
-    onConfirm,
-  } = props;
+const JoinGroupDialog = (props) => {
+  const { shouldShow, isLoading, isActiveMember, groupName, onQuit, onClose } =
+    props;
 
   return (
-    <ResponsiveLayout
-      DesktopLayout={Modal}
-      MobileLayout={BottomSheet}
+    <ModalConfirmation
       shouldShow={shouldShow}
-      isOpen={shouldShow}
-      onClose={onDismiss}
-      onDismiss={onDismiss}
-      shouldDismissOnClick
-      noScroll
+      onClose={!isLoading ? onClose : undefined}
+      shouldDismissOnClick={false}
     >
       <StyledDialog>
-        <main>
+        <header>
           {isActiveMember ? (
-            <h4>Quitter le groupe {groupName}&nbsp;?</h4>
+            <h3>Quitter le groupe {groupName}&nbsp;?</h3>
           ) : (
-            <h4>Ne plus suivre le groupe {groupName}&nbsp;?</h4>
+            <h3>Ne plus suivre le groupe {groupName}&nbsp;?</h3>
           )}
+        </header>
+        <article>
           {isActiveMember ? (
             <p>
-              Voulez-vous vraiment quitter le groupe ? Vous ne recevrez plus
-              aucune actualité de ce groupe.
-              <br />
+              Voulez-vous vraiment quitter le groupe&nbsp;? Vous ne recevrez
+              plus aucune actualité de ce groupe.
+              <Spacer size=".5rem" />
               Vous pourrez rejoindre le groupe à nouveau à tout moment.
             </p>
           ) : (
             <p>
               Vous ne recevrez plus les actualités de ce groupe.
-              <br />
+              <Spacer size=".5rem" />
               Vous pouvez suivre ce groupe à nouveau à tout moment.
             </p>
           )}
-        </main>
+        </article>
         <footer>
-          <Button color="danger" onClick={onConfirm} disabled={isLoading}>
+          <Button
+            color="danger"
+            onClick={onQuit}
+            disabled={isLoading}
+            loading={isLoading}
+          >
             {isActiveMember ? "Quitter le groupe" : "Ne plus suivre"}
           </Button>
-          <Button color="default" onClick={onDismiss} disabled={isLoading}>
+          <Button onClick={onClose} disabled={isLoading}>
             Annuler
           </Button>
         </footer>
       </StyledDialog>
-    </ResponsiveLayout>
+    </ModalConfirmation>
   );
 };
-QuitGroupButton.propTypes = {
-  groupName: PropTypes.string.isRequired,
-  isActiveMember: PropTypes.bool,
+
+JoinGroupDialog.propTypes = {
   shouldShow: PropTypes.bool,
   isLoading: PropTypes.bool,
-  onConfirm: PropTypes.func.isRequired,
-  onDismiss: PropTypes.func.isRequired,
+  isActiveMember: PropTypes.bool,
+  groupName: PropTypes.string.isRequired,
+  onQuit: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
 };
-export default QuitGroupButton;
+
+export default JoinGroupDialog;

--- a/agir/groups/components/groupPage/GroupUserActions/StyledDialog.js
+++ b/agir/groups/components/groupPage/GroupUserActions/StyledDialog.js
@@ -1,0 +1,35 @@
+import styled from "styled-components";
+
+const StyledDialog = styled.div`
+  padding: 0 1rem;
+
+  header {
+    margin: 0;
+    padding: 0;
+
+    h3 {
+      margin: 0;
+      line-height: 1.5;
+    }
+  }
+
+  article {
+    padding: 0.75rem 0 1rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+
+    strong {
+      font-weight: 600;
+    }
+  }
+
+  footer {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+`;
+
+export default StyledDialog;

--- a/agir/groups/components/groupPage/GroupUserActions/StyledMenuList.js
+++ b/agir/groups/components/groupPage/GroupUserActions/StyledMenuList.js
@@ -17,6 +17,10 @@ const StyledList = styled.ul`
     padding: 1.5rem;
   }
 
+  li + li {
+    margin-top: 0.5rem;
+  }
+
   button {
     display: flex;
     align-items: center;

--- a/agir/groups/rules.py
+++ b/agir/groups/rules.py
@@ -151,6 +151,9 @@ rules.add_perm(
     is_authenticated_person & own_membership_has_higher_rights,
 )
 rules.add_perm(
+    "groups.update_own_membership", is_authenticated_person & is_own_membership,
+)
+rules.add_perm(
     "groups.delete_membership",
     is_authenticated_person & is_own_membership & (~is_group_only_referent),
 )

--- a/agir/groups/serializers.py
+++ b/agir/groups/serializers.py
@@ -143,6 +143,7 @@ class SupportGroupDetailSerializer(FlexibleFieldsMixin, serializers.Serializer):
     isActiveMember = serializers.SerializerMethodField(read_only=True,)
     isManager = serializers.SerializerMethodField(read_only=True,)
     isReferent = serializers.SerializerMethodField(read_only=True,)
+    personalInfoConsent = serializers.SerializerMethodField(read_only=True)
 
     name = serializers.CharField(read_only=True,)
     type = serializers.SerializerMethodField(read_only=True,)
@@ -198,6 +199,12 @@ class SupportGroupDetailSerializer(FlexibleFieldsMixin, serializers.Serializer):
         return (
             self.membership is not None
             and self.membership.membership_type >= Membership.MEMBERSHIP_TYPE_REFERENT
+        )
+
+    def get_personalInfoConsent(self, obj):
+        return (
+            self.membership is not None
+            and self.membership.personal_information_sharing_consent
         )
 
     def get_contact(self, instance):
@@ -425,7 +432,7 @@ class MembershipSerializer(serializers.ModelSerializer):
         source="membership_type", choices=Membership.MEMBERSHIP_TYPE_CHOICES
     )
     personalInfoConsent = serializers.BooleanField(
-        source="personal_information_sharing_consent", read_only=True
+        source="personal_information_sharing_consent"
     )
     hasGroupNotifications = serializers.SerializerMethodField(read_only=True)
 

--- a/agir/groups/urls.py
+++ b/agir/groups/urls.py
@@ -130,6 +130,11 @@ api_urlpatterns = [
         views.RetrieveUpdateDestroySupportGroupExternalLinkAPIView.as_view(),
         name="api_group_link_retrieve_update_destroy",
     ),
+    path(
+        "<uuid:group_pk>/membre/",
+        views.GroupUpdateOwnMembershipAPIView.as_view(),
+        name="api_group_update_own_membership",
+    ),
 ]
 
 urlpatterns = [


### PR DESCRIPTION
- add UpdateOwnMembershipAPIView to allow a group member to update his/her own Membership instance
- add a JoinGroupDialog on the group detail page to allow non-members to join the group and/or to accept sharing their personal information with the group management
- add an EditMembershipDialog on the group detail page to allow already-members to accept/deny sharing their personal information with the group management
- refactor GroupUsersActions components

