### PR TITLE
Condition scroll from parent management on mobile

### DIFF
--- a/agir/front/components/genericComponents/ObjectManagement/ManagementMenu.js
+++ b/agir/front/components/genericComponents/ObjectManagement/ManagementMenu.js
@@ -192,7 +192,7 @@ const ManagementMenu = (props) => {
   );
 
   return (
-    <StyledMenu>
+    <StyledMenu id="managementMenu">
       <Hide over>
         <BackButton onClick={onBack} />
       </Hide>

--- a/agir/front/components/genericComponents/ObjectManagement/ManagementPanel.js
+++ b/agir/front/components/genericComponents/ObjectManagement/ManagementPanel.js
@@ -1,8 +1,9 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 
 import style from "@agir/front/genericComponents/_variables.scss";
+import { useIsDesktop } from "@agir/front/genericComponents/grid";
 
 const StyledContainer = styled.div`
   background-color: rgba(0, 0, 0, 0.5);
@@ -48,13 +49,26 @@ const StyledPanel = styled.div`
   }
 `;
 
-const ManagementPanel = ({ children }) => (
-  <StyledContainer>
-    <StyledPanel>
-      <main>{children}</main>
-    </StyledPanel>
-  </StyledContainer>
-);
+const ManagementPanel = ({ children }) => {
+  const isDesktop = useIsDesktop();
+
+  // Remove mutliple scroll overlay on mobile
+  useEffect(() => {
+    const managementMenu = document.querySelector("#managementMenu");
+    if (!isDesktop) {
+      managementMenu.style.overflow = "hidden";
+    }
+    return () => (managementMenu.style.overflow = "auto");
+  }, []);
+
+  return (
+    <StyledContainer>
+      <StyledPanel>
+        <main>{children}</main>
+      </StyledPanel>
+    </StyledContainer>
+  );
+};
 
 ManagementPanel.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
Résout la sensation de freeze sur certains mobiles dans les panneaux de menu où, sur mobile, plusieurs blocs qui défilent se superposent.
Bug reproduit sous Firefox.
