### PR TITLE
Fix font sizes (by using pxs instead of rems) of mobile navigation elements

### DIFF
--- a/agir/events/components/common/UpcomingEvents/MiniEventCard.js
+++ b/agir/events/components/common/UpcomingEvents/MiniEventCard.js
@@ -10,7 +10,7 @@ import { displayHumanDateString } from "@agir/lib/utils/time";
 const StyledCard = styled(Link)`
   display: block;
   width: 254px;
-  height: 74px;
+  min-height: 74px;
   padding: 1rem;
   border-radius: ${(props) => props.theme.borderRadius};
   box-shadow: ${(props) => props.theme.cardShadow};

--- a/agir/front/components/app/ActionButtons.js
+++ b/agir/front/components/app/ActionButtons.js
@@ -5,7 +5,7 @@ import Link from "./Link";
 import { RawFeatherIcon } from "@agir/front/genericComponents/FeatherIcon";
 
 const StyledButton = styled(Link)`
-  width: 5.063rem;
+  max-width: 81px;
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
@@ -14,6 +14,7 @@ const StyledButton = styled(Link)`
   overflow-wrap: normal;
 
   @media (min-width: ${(props) => props.theme.collapse}px) {
+    width: 5.063rem;
     flex-flow: row nowrap;
     width: 100%;
     text-align: left;
@@ -31,16 +32,17 @@ const StyledButton = styled(Link)`
   }
 
   & > span {
-    width: 3.125rem;
-    height: 3.125rem;
+    width: 50px;
+    height: 50px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    background-color: ${(props) => props.theme[props.color]};
     color: ${(props) => props.theme.white};
     border-radius: 100%;
 
     @media (min-width: ${(props) => props.theme.collapse}px) {
+      width: 3.125rem;
+      height: 3.125rem;
       transform: scale(0.75);
       transform-origin: center left;
     }
@@ -55,7 +57,8 @@ const StyledButton = styled(Link)`
     font-size: 0.875rem;
 
     @media (max-width: ${(props) => props.theme.collapse}px) {
-      margin-top: 0.688rem;
+      margin-top: 11px;
+      font-size: 14px;
     }
   }
 
@@ -68,13 +71,20 @@ const StyledButton = styled(Link)`
 `;
 
 const StyledButtons = styled.nav`
+  width: 100%;
+  overflow-x: hidden;
   padding: 0;
   margin: 0;
 
   @media (max-width: ${(props) => props.theme.collapse}px) {
     display: flex;
     justify-content: center;
-    gap: 2rem;
+    gap: 32px;
+  }
+
+  @media (max-width: 340px) {
+    gap: 0;
+    justify-content: space-between;
   }
 
   ${StyledButton} {
@@ -85,8 +95,8 @@ const StyledButtons = styled.nav`
 const ActionButtons = () => {
   return (
     <StyledButtons>
-      <StyledButton route="createEvent" color="secondary500">
-        <span>
+      <StyledButton route="createEvent">
+        <span css={`background-color: ${(props) => props.theme.secondary500};`}>
           <svg
             width="24"
             height="24"
@@ -108,12 +118,12 @@ const ActionButtons = () => {
         </span>
         <strong>Créer un événement</strong>
       </StyledButton>
-      <StyledButton route="createContact" color="primary500">
-        <RawFeatherIcon name="user-plus" />
+      <StyledButton route="createContact">
+        <RawFeatherIcon css={`background-color: ${(props) => props.theme.primary500};`} name="user-plus" />
         <strong>Ajouter un contact</strong>
       </StyledButton>
-      <StyledButton route="donations" color="redNSP">
-        <RawFeatherIcon name="heart" />
+      <StyledButton route="donations">
+        <RawFeatherIcon css={`background-color: ${(props) => props.theme.redNSP};`} name="heart" />
         <strong>Faire un don</strong>
       </StyledButton>
     </StyledButtons>

--- a/agir/front/components/app/Navigation/BottomBar/BottomBar.js
+++ b/agir/front/components/app/Navigation/BottomBar/BottomBar.js
@@ -35,10 +35,13 @@ const MenuLink = styled(Link)`
   }
 
   ${Title} {
-    font-size: 0.625rem;
+    font-size: 10px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 
     @media (max-width: 340px) {
-      display: none;
+      font-size: 8px;
     }
   }
 
@@ -48,7 +51,7 @@ const MenuLink = styled(Link)`
     right: 14px;
 
     @media (max-width: 340px) {
-      top: 16px;
+      top: 9px;
     }
   }
 `;
@@ -64,6 +67,7 @@ const StyledBottomBar = styled.nav`
   padding: 0 0.5rem;
   z-index: ${(props) => props.theme.zindexBottomBar};
   isolation: isolate;
+  overflow: hidden;
 
   ul {
     padding: 0;
@@ -76,6 +80,7 @@ const StyledBottomBar = styled.nav`
     li {
       flex: 1 1 auto;
       max-width: 70px;
+      min-width: 1px;
     }
   }
 `;

--- a/agir/front/components/app/Navigation/TopBar/MobileNavBar/DashboardPageBar.js
+++ b/agir/front/components/app/Navigation/TopBar/MobileNavBar/DashboardPageBar.js
@@ -20,7 +20,7 @@ export const DashboardPageBar = (props) => {
         </IconLink>
       ) : (
         <IconLink href={routeConfig.events.getLink()}>
-          <RawFeatherIcon name="arrow-left" width="1.5rem" height="1.5rem" />
+          <RawFeatherIcon name="arrow-left" width="24px" height="24px" />
         </IconLink>
       )}
       <h1>

--- a/agir/front/components/app/Navigation/TopBar/MobileNavBar/RightLink.js
+++ b/agir/front/components/app/Navigation/TopBar/MobileNavBar/RightLink.js
@@ -14,13 +14,13 @@ export const RightLink = (props) => {
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
 
   if (isLoading) {
-    return <IconLink as={Spacer} size="2rem" />;
+    return <IconLink as={Spacer} size="32px" />;
   }
 
   if (!user) {
     return (
       <IconLink route="login">
-        <RawFeatherIcon name="user" width="1.5rem" height="1.5rem" />
+        <RawFeatherIcon name="user" width="24px" height="24px" />
       </IconLink>
     );
   }
@@ -34,7 +34,7 @@ export const RightLink = (props) => {
         title={settingsLink.label}
         aria-label={settingsLink.label}
       >
-        <RawFeatherIcon name="settings" width="1.5rem" height="1.5rem" />
+        <RawFeatherIcon name="settings" width="24px" height="24px" />
       </IconLink>
     );
   }
@@ -52,8 +52,8 @@ export const RightLink = (props) => {
         image={user.image}
         style={{
           border: "none",
-          width: "2rem",
-          height: "2rem",
+          width: "32px",
+          height: "32px",
         }}
       />
       <BottomSheet

--- a/agir/front/components/app/Navigation/TopBar/MobileNavBar/SecondaryPageBar.js
+++ b/agir/front/components/app/Navigation/TopBar/MobileNavBar/SecondaryPageBar.js
@@ -26,7 +26,7 @@ const SecondaryPageBar = (props) => {
         title={backLink.label}
         aria-label={backLink.label}
       >
-        <RawFeatherIcon name="arrow-left" width="1.5rem" height="1.5rem" />
+        <RawFeatherIcon name="arrow-left" width="24px" height="24px" />
       </IconLink>
       <h2>{title}</h2>
       <RightLink

--- a/agir/front/components/app/Navigation/TopBar/MobileNavBar/StyledBar.js
+++ b/agir/front/components/app/Navigation/TopBar/MobileNavBar/StyledBar.js
@@ -12,7 +12,7 @@ const StyledBar = styled.div`
   flex-flow: row nowrap;
   align-items: center;
   justify-content: space-between;
-  padding: 0 1.5rem;
+  padding: 0 24px;
 
   & > * {
     flex: 0 0 auto;
@@ -21,7 +21,7 @@ const StyledBar = styled.div`
   & > h1,
   & > h2 {
     margin: 0;
-    padding: 0 1rem;
+    padding: 0 16px;
     flex: 1 1 auto;
     text-align: center;
   }
@@ -35,7 +35,7 @@ const StyledBar = styled.div`
   }
 
   & > h2 {
-    font-size: 1rem;
+    font-size: 16px;
     line-height: 1.5;
     font-weight: 500;
     white-space: nowrap;
@@ -46,8 +46,8 @@ const StyledBar = styled.div`
 
   ${IconLink} {
     display: flex;
-    height: 2rem;
-    width: 2rem;
+    height: 32px;
+    width: 32px;
     align-items: center;
     color: ${(props) => props.theme.black1000};
     line-height: 0;


### PR DESCRIPTION
Ce changement permettra de garder des éléments de navigation stables et visibles sur mobile, même pour les personnes qui ont définit une taille de police de leur mobile par défaut supérieure à 16px