### PR TITLE
Fix event creation unload handling

### DIFF
--- a/agir/events/components/createEventPage/CreateEvent.js
+++ b/agir/events/components/createEventPage/CreateEvent.js
@@ -13,7 +13,6 @@ import { useMissingRequiredEventDocuments } from "@agir/events/common/hooks";
 import { routeConfig } from "@agir/front/app/routes.config";
 
 import Link from "@agir/front/app/Link";
-import UnloadPrompt from "@agir/front/app/UnloadPrompt";
 import { Container, Hide } from "@agir/front/genericComponents/grid";
 import PageFadeIn from "@agir/front/genericComponents/PageFadeIn";
 import { RawFeatherIcon } from "@agir/front/genericComponents/FeatherIcon";
@@ -183,7 +182,6 @@ const CreateEvent = () => {
           </div>
         </StyledContainer>
       )}
-      <UnloadPrompt enabled={isSessionLoaded && !isBlocked} />
     </PageFadeIn>
   );
 };

--- a/agir/events/components/createEventPage/EventForm/index.js
+++ b/agir/events/components/createEventPage/EventForm/index.js
@@ -14,7 +14,8 @@ import { createEvent } from "@agir/events/common/api";
 
 import Button from "@agir/front/genericComponents/Button";
 import Spacer from "@agir/front/genericComponents/Spacer";
-import LocationField from "@agir/front/formComponents/LocationField.js";
+import LocationField from "@agir/front/formComponents/LocationField";
+import UnloadPrompt from "@agir/front/app/UnloadPrompt";
 
 import NameField from "./NameField";
 import OrganizerGroupField from "@agir/events/common/OrganizerGroupField";
@@ -411,6 +412,7 @@ const EventForm = () => {
       >
         Vous pourrez modifier ces informations après la création de l’événement.
       </p>
+      <UnloadPrompt enabled={!newEventPk} allowedRoutes="createEvent" />
     </StyledForm>
   );
 };

--- a/agir/front/components/app/UnloadPrompt.js
+++ b/agir/front/components/app/UnloadPrompt.js
@@ -1,19 +1,38 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { Prompt } from "react-router-dom";
 import { useBeforeUnload } from "react-use";
+
+import { routeConfig } from "@agir/front/app/routes.config";
 
 const DEFAULT_MESSAGE =
   "Cette page vous demande de confirmer sa fermeture; des données que vous avez saisies pourraient ne pas être enregistrées. Confirmez-vous vouloir quitter la page ?";
 
 const UnloadPrompt = (props) => {
-  const { enabled, message = DEFAULT_MESSAGE } = props;
+  const { enabled, message = DEFAULT_MESSAGE, allowedRoutes } = props;
   useBeforeUnload(enabled, message);
-  return <Prompt when={enabled} message={message} />;
+  const msg = useCallback(
+    (location, action) => {
+      if (!allowedRoutes) {
+        return message;
+      }
+      return (
+        allowedRoutes
+          .split(",")
+          .some(
+            (route) =>
+              routeConfig[route] && routeConfig[route].match(location.pathname)
+          ) || message
+      );
+    },
+    [allowedRoutes, message]
+  );
+  return <Prompt when={enabled} message={msg} />;
 };
 UnloadPrompt.propTypes = {
   enabled: PropTypes.bool,
   message: PropTypes.string,
+  allowedRoutes: PropTypes.string,
 };
 
 export default UnloadPrompt;


### PR DESCRIPTION
- allow passing a list of allowed routes (i.e. routes that do not need confirmation) to the UnloadPrompt component
- remove unload prompt from event creation : (a) upon form submission success (b) upon subtype panel opening