### PR TITLE
Split user groups and user group suggestions into two endpoints

### DIFF
--- a/agir/activity/components/ActivityPage/ActivityCard/GenericCardContainer.js
+++ b/agir/activity/components/ActivityPage/ActivityCard/GenericCardContainer.js
@@ -219,7 +219,6 @@ export const GenericCardContainer = (props) => {
 GenericCardContainer.propTypes = {
   id: PropTypes.number,
   status: PropTypes.oneOf(Object.values(ACTIVITY_STATUS)),
-  type: PropTypes.string.isRequired,
   event: PropTypes.object,
   timestamp: PropTypes.string,
   children: PropTypes.node,

--- a/agir/donations/components/donationPage/DonationPage.js
+++ b/agir/donations/components/donationPage/DonationPage.js
@@ -277,8 +277,8 @@ const DonationPage = () => {
           }
           group={group && group.isCertified ? group : null}
           hasGroups={
-            Array.isArray(userGroups?.groups) &&
-            userGroups.groups.some((group) => group.isCertified)
+            Array.isArray(userGroups) &&
+            userGroups.some((group) => group.isCertified)
           }
           isLoading={isLoading}
           error={errors?.amount}

--- a/agir/front/components/serviceWorker/cachedRoutes.config.js
+++ b/agir/front/components/serviceWorker/cachedRoutes.config.js
@@ -20,6 +20,7 @@ const config = [
   new RegExp(".+/api/evenements/[0-9a-f-]+/details/$"),
 
   "/api/groupes/",
+  "/api/groupes/suggestions/",
   new RegExp("/api/groupes/[0-9a-f-]+/$"),
   new RegExp("/api/groupes/[0-9a-f-]+/suggestions/$"),
   new RegExp("/api/groupes/[0-9a-f-]+/evenements/a-venir/$"),

--- a/agir/front/views.py
+++ b/agir/front/views.py
@@ -133,7 +133,10 @@ class HomepageView(BaseAppCachedView):
 
 
 class UserSupportGroupsView(BaseAppSoftAuthView):
-    api_preloads = [reverse_lazy("api_user_groups")]
+    def get_api_preloads(self):
+        if self.request.user.person.supportgroups.active().exists():
+            return [reverse_lazy("api_user_groups")]
+        return [reverse_lazy("api_user_group_suggestions")]
 
 
 class UserMessagesView(BaseAppHardAuthView):

--- a/agir/groups/urls.py
+++ b/agir/groups/urls.py
@@ -32,6 +32,11 @@ legacy_urlpatterns = [
 api_urlpatterns = [
     path("", views.UserGroupsView.as_view(), name="api_user_groups"),
     path(
+        "suggestions/",
+        views.UserGroupSuggestionsView.as_view(),
+        name="api_user_group_suggestions",
+    ),
+    path(
         "recherche/",
         views.GroupSearchAPIView.as_view(),
         name="api_group_search",

--- a/agir/notifications/components/NotificationSettings/NotificationSettings.js
+++ b/agir/notifications/components/NotificationSettings/NotificationSettings.js
@@ -18,7 +18,6 @@ import { routeConfig } from "@agir/front/app/routes.config";
 import { updateProfile } from "@agir/front/authentication/api";
 
 const NotificationSettings = (props) => {
-  const { data: groupData } = useSWR("/api/groupes/");
   const {
     data: userNotifications,
     mutate,
@@ -30,9 +29,7 @@ const NotificationSettings = (props) => {
 
   const { data: profile, mutate: mutateProfile } = useSWR("/api/user/profile/");
 
-  const notifications = useMemo(() => {
-    return getAllNotifications(groupData?.groups, user);
-  }, [groupData, user]);
+  const notifications = useMemo(() => getAllNotifications(user), [user]);
 
   const allActiveNotifications = useMemo(
     () => ({
@@ -100,7 +97,7 @@ const NotificationSettings = (props) => {
       activeNotifications={allActiveNotifications}
       onChange={handleChange}
       disabled={isLoading || isValidating}
-      ready={!!userNotifications && !!groupData}
+      ready={!!userNotifications}
     />
   );
 };

--- a/agir/notifications/components/common/notifications.config.js
+++ b/agir/notifications/components/common/notifications.config.js
@@ -349,10 +349,10 @@ const getNewsletterNotifications = (user) => {
   );
 };
 
-export const getAllNotifications = (groups = [], user) => [
+export const getAllNotifications = (user) => [
   ...getNewsletterNotifications(user),
   ...PERSON_NOTIFICATIONS,
-  ...getGroupNotifications(groups),
+  ...getGroupNotifications(user?.groups),
 ];
 
 export const getNewsletterStatus = (newsletters) => {

--- a/agir/people/components/contacts/CreateContactPage/index.js
+++ b/agir/people/components/contacts/CreateContactPage/index.js
@@ -28,12 +28,9 @@ const CreateContactPage = () => {
   const step = Math.max(STEPS.indexOf(params?.step), 0);
 
   const { data: session } = useSWR("/api/session/");
-  const { data: userGroups } = useSWR("/api/groupes/");
-
   const user = session ? session?.user : undefined;
-  const groups = userGroups ? userGroups?.groups : undefined;
-  const pageIsReady =
-    typeof user !== "undefined" && typeof groups !== "undefined";
+  const groups = user?.groups || [];
+  const pageIsReady = typeof user !== "undefined";
 
   /**
    * Handles submission of the contact form (1st step) data for validation only


### PR DESCRIPTION
+ split user groups and group suggestions into two endpoints
+ conditionnaly call only one endpoint on user groups' page
+ avoid calling user groups endpoint if session data is enough
  (activities, contact creation)