### PR TITLE
quickfix: rollback `babel-plugin-styled-components` to v2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "babel-jest": "^27.5.1",
         "babel-loader": "^8.2.3",
         "babel-plugin-polyfill-corejs3": "^0.5.2",
-        "babel-plugin-styled-components": "^2.0.5",
+        "babel-plugin-styled-components": "2.0.2",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
         "clean-webpack-plugin": "^4.0.0",
         "css-loader": "^6.6.0",
@@ -13010,15 +13010,14 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.5.tgz",
-      "integrity": "sha512-A7kfST5odbf8Ev42OQbj5teEiT8DskpRoQ/iPYePLLdcTCAsodpYKqtoy4SJthpsGzQKc2vvnrtlUgdmJq6WKQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.2.tgz",
+      "integrity": "sha512-7eG5NE8rChnNTDxa6LQfynwgHTVOYYaHJbUYSlOhk8QBXIQiMBKq4gyfHBBKPrxUcVBXVJL61ihduCpCQbuNbw==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
+        "lodash": "^4.17.11"
       },
       "peerDependencies": {
         "styled-components": ">= 2"
@@ -43592,15 +43591,14 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.5.tgz",
-      "integrity": "sha512-A7kfST5odbf8Ev42OQbj5teEiT8DskpRoQ/iPYePLLdcTCAsodpYKqtoy4SJthpsGzQKc2vvnrtlUgdmJq6WKQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.2.tgz",
+      "integrity": "sha512-7eG5NE8rChnNTDxa6LQfynwgHTVOYYaHJbUYSlOhk8QBXIQiMBKq4gyfHBBKPrxUcVBXVJL61ihduCpCQbuNbw==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
+        "lodash": "^4.17.11"
       }
     },
     "babel-plugin-syntax-jsx": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "babel-jest": "^27.5.1",
     "babel-loader": "^8.2.3",
     "babel-plugin-polyfill-corejs3": "^0.5.2",
-    "babel-plugin-styled-components": "^2.0.5",
+    "babel-plugin-styled-components": "2.0.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^6.6.0",


### PR DESCRIPTION
cf. https://github.com/styled-components/babel-plugin-styled-components/issues/373#issuecomment-1050158785