### PR TITLE
feat: split biggest front dependencies into their own chunk for longer-term caching

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -300,7 +300,7 @@ module.exports = (type = CONFIG_TYPES.ES5) => ({
             view: [
               "struct",
               {
-                data: `#.stats.compilations.(
+                data: `#.stats.compilations.sort(time desc)[0].(
                   $compilation: $;
                     modules.({
                       module: $,
@@ -364,6 +364,33 @@ module.exports = (type = CONFIG_TYPES.ES5) => ({
   optimization: {
     splitChunks: {
       chunks: "all",
+      cacheGroups: {
+        emojiMart: {
+          test: /[\\/]node_modules[\\/]emoji-mart[\\/]/,
+          name: "em",
+          chunks: "all",
+        },
+        openlayers: {
+          test: /[\\/]node_modules[\\/]ol[\\/]/,
+          name: "ol",
+          chunks: "all",
+        },
+        quill: {
+          test: /[\\/]node_modules[\\/](quill|react-quill)[\\/]/,
+          name: "ql",
+          chunks: "all",
+        },
+        react: {
+          test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/,
+          name: "rt",
+          chunks: "all",
+        },
+        sentry: {
+          test: /[\\/]node_modules[\\/]@sentry[\\/]/,
+          name: "sy",
+          chunks: "all",
+        },
+      },
     },
     moduleIds: "deterministic",
     minimize: type !== CONFIG_TYPES.DEV,


### PR DESCRIPTION
```
- emoji-mart		(575.28 kb)
- ol			(349.25 kb)
- quill		(275.07 kb)
- React/React-DOM 	(121.53 kb)
- @sentry/* 		(104.69 kb)
```