### PR TITLE
Search : fix search groups and events from states

### DIFF
--- a/agir/events/models.py
+++ b/agir/events/models.py
@@ -210,6 +210,9 @@ class EventQuerySet(models.QuerySet):
             + SearchVector(
                 models.F("report_content"), config="french_unaccented", weight="C"
             )
+            + SearchVector(
+                models.F("location_state"), config="french_unaccented", weight="D"
+            )
         )
         query = PrefixSearchQuery(query, config="french_unaccented")
 

--- a/agir/front/api_views.py
+++ b/agir/front/api_views.py
@@ -2,7 +2,6 @@ import json
 
 from django.conf import settings
 from django.utils import timezone
-from rest_framework import permissions
 from rest_framework.generics import (
     ListAPIView,
 )

--- a/agir/groups/components/groupPage/GroupLocation.js
+++ b/agir/groups/components/groupPage/GroupLocation.js
@@ -101,9 +101,7 @@ const GroupLocation = (props) => {
           {(zip || city) && (
             <span>{[zip, city].filter(Boolean).join(" ")}</span>
           )}
-          {(state || country) && (
-            <span>{[state, country].filter(Boolean).join(", ")}</span>
-          )}
+          {state ? <span>{state}</span> : <span>{country}</span>}
         </p>
         <p>
           {coordinates && Array.isArray(coordinates.coordinates) ? (

--- a/agir/groups/models.py
+++ b/agir/groups/models.py
@@ -51,7 +51,13 @@ class SupportGroupQuerySet(models.QuerySet):
                 models.F("location_zip"), config="french_unaccented", weight="B"
             )
             + SearchVector(
+                models.F("location_state"), config="french_unaccented", weight="B"
+            )
+            + SearchVector(
                 models.F("description"), config="french_unaccented", weight="C"
+            )
+            + SearchVector(
+                models.F("location_name"), config="french_unaccented", weight="D"
             )
         )
         query = PrefixSearchQuery(query, config="french_unaccented")

--- a/agir/lib/management/commands/add_locations_state.py
+++ b/agir/lib/management/commands/add_locations_state.py
@@ -1,0 +1,41 @@
+from agir.groups.models import SupportGroup
+from agir.events.models import Event
+from django.db.models import Q
+from django.core.management import BaseCommand
+
+
+class Command(BaseCommand):
+    def print_line(self, line):
+        self.stdout.write(f"   {line}")
+
+    def update_groups_state(self):
+        groups = SupportGroup.objects.exclude(Q(location_country=""))
+
+        for group in groups:
+            country = group.location_country
+            group.location_state = country.name
+
+        SupportGroup.objects.bulk_update(groups, ["location_state"])
+        self.print_line(f"Updated : {len(groups)} groupes")
+
+    def update_events_state(self):
+        events = Event.objects.exclude(Q(location_country=""))
+
+        for event in events:
+            country = event.location_country
+            event.location_state = country.name
+
+        Event.objects.bulk_update(events, ["location_state"])
+        self.print_line(f"Updated : {len(events)} événements")
+
+    def handle(self, *args, **options):
+
+        self.stdout.write("\n")
+        self.stdout.write(
+            f"** Localisation — remplissage des champs 'state' des groupes et événements **",
+            self.style.WARNING,
+        )
+
+        self.update_groups_state()
+        self.update_events_state()
+        self.stdout.write(self.style.SUCCESS("SUCCESS !"))

--- a/agir/lib/serializers.py
+++ b/agir/lib/serializers.py
@@ -54,6 +54,7 @@ class LocationSerializer(serializers.Serializer):
     zip = serializers.CharField(source="location_zip")
     city = serializers.CharField(source="location_city")
     country = CountryField(source="location_country")
+    state = serializers.CharField(source="location_state")
     address = serializers.SerializerMethodField()
 
     shortAddress = serializers.CharField(source="short_address", required=False)
@@ -193,7 +194,7 @@ class NestedContactSerializer(serializers.Serializer):
 class NestedLocationSerializer(serializers.Serializer):
     """A nested serializer for the fields defined by :py:class:`lib.models.LocationMixin`
 
-    All these fields will be collected and serialized as a a JSON object.
+    All these fields will be collected and serialized as a JSON object.
     """
 
     name = NullableCharField(
@@ -226,12 +227,18 @@ class NestedLocationSerializer(serializers.Serializer):
     zip = NullableCharField(
         label="code postal", max_length=20, required=True, source="location_zip"
     )
-    state = NullableCharField(
-        label="état", max_length=40, required=False, source="location_state"
-    )
     country = NullableCountryField(
         label="pays", required=True, source="location_country"
     )
+    state = serializers.SerializerMethodField()
+
+    # Set state from country code
+    def get_state(self, obj):
+        country = obj.location_country
+        if not country:
+            return
+        obj.location_state = country.name
+        obj.save()
 
     def __init__(self, instance=None, data=empty, **kwargs):
         kwargs.setdefault("source", "*")


### PR DESCRIPTION
- Les `location.state` n'étaient pas remplis et concernent les événements et groupes
- Ajout du `state` automatiquement à l'ajout et modification du `NestedLocationSerializer`
- Ajout de la commande `add_locations_state` à lancer pour remplir tous ces champs à partir des `location_country.name`
- Recherche des groupes : ajout des `location_state` et `location_name`
- Recherche des événements : ajout de `location_state`
- Mise à jour cardLocation avec l'état plutôt que countryCode