### PR TITLE
Remove useless api calls

### DIFF
--- a/agir/front/components/app/Navigation/TopBar/MobileNavBar/RightLink.js
+++ b/agir/front/components/app/Navigation/TopBar/MobileNavBar/RightLink.js
@@ -8,27 +8,13 @@ import Spacer from "@agir/front/genericComponents/Spacer";
 import ButtonMuteMessage from "@agir/front/genericComponents/ButtonMuteMessage";
 import ButtonLockMessage from "@agir/front/genericComponents/ButtonLockMessage";
 
-import { MessageOptions } from "@agir/msgs/MessagePage/MessageThreadMenu.js";
+import { MessageOptions } from "@agir/msgs/MessagePage/MessageThreadMenu";
 import { IconLink } from "./StyledBar";
-import UserMenu from "../UserMenu";
-import { routeConfig } from "@agir/front/app/routes.config";
-import { useMessageSWR } from "@agir/msgs/common/hooks";
-import { useCurrentLocation } from "@agir/front/app/utils.js";
+import UserMenu from "@agir/front/app/Navigation/TopBar/UserMenu";
 
 export const RightLink = (props) => {
   const { isLoading, user, settingsLink } = props;
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
-
-  const pathname = useCurrentLocation();
-  const matchMessagesPage = pathname === "/messages/";
-  const matchMessagePage =
-    routeConfig.messages.match(pathname) && !matchMessagesPage;
-  const cleanPathname = pathname.slice(0, pathname.length - 1);
-  const messagePk = matchMessagePage
-    ? cleanPathname.slice(cleanPathname.lastIndexOf("/") + 1)
-    : undefined;
-
-  const { currentMessage } = useMessageSWR(messagePk);
 
   if (isLoading) {
     return <IconLink as={Spacer} size="32px" />;
@@ -42,24 +28,25 @@ export const RightLink = (props) => {
     );
   }
 
-  if (matchMessagesPage) {
-    return <MessageOptions />;
-  }
-
   // Show muted message settings
-  if (matchMessagePage) {
-    const isAuthor = currentMessage?.author.id === user.id;
-    const isManager = currentMessage?.group?.isManager;
+  if (settingsLink?.message?.id) {
+    const { message } = settingsLink;
+    const isAuthor = message.author.id === user.id;
+    const isManager = message.group?.isManager;
 
     return (
       <>
         {(isManager || isAuthor) && (
-          <ButtonLockMessage message={{ id: messagePk }} />
+          <ButtonLockMessage message={{ id: message.id }} />
         )}
         <Spacer size="1rem" style={{ display: "inline-block" }} />
-        <ButtonMuteMessage message={{ id: messagePk }} />
+        <ButtonMuteMessage message={{ id: message.id }} />
       </>
     );
+  }
+
+  if (settingsLink?.messageSettings) {
+    return <MessageOptions />;
   }
 
   if (settingsLink) {

--- a/agir/front/components/app/routes.config.js
+++ b/agir/front/components/app/routes.config.js
@@ -351,6 +351,9 @@ export const routeConfig = {
     hasLayout: false,
     hideFeedbackButton: true,
     hideFooter: true,
+    topBarRightLink: {
+      messageSettings: true,
+    },
   }),
   createContact: new RouteConfig({
     id: "createContact",

--- a/agir/groups/components/groupPage/GroupMessagePage/index.js
+++ b/agir/groups/components/groupPage/GroupMessagePage/index.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React, { useEffect, useMemo } from "react";
 import { Redirect } from "react-router-dom";
 
+import { getMessageSubject } from "@agir/msgs/common/utils";
 import { routeConfig } from "@agir/front/app/routes.config";
 import { useGroupMessage } from "@agir/groups/groupPage/hooks";
 import { useIsOffline } from "@agir/front/offline/hooks";
@@ -10,7 +11,12 @@ import {
   useDispatch,
   useSelector,
 } from "@agir/front/globalContext/GlobalContext";
-import { setBackLink, setAdminLink } from "@agir/front/globalContext/actions";
+import {
+  setBackLink,
+  setAdminLink,
+  setPageTitle,
+  setTopBarRightLink,
+} from "@agir/front/globalContext/actions";
 import {
   getIsSessionLoaded,
   getUser,
@@ -87,6 +93,14 @@ const Page = ({ groupPk, messagePk }) => {
       );
     }
   }, [group, dispatch]);
+
+  useEffect(() => {
+    const pageTitle = message
+      ? getMessageSubject(message)
+      : "Message du groupe";
+    dispatch(setPageTitle(pageTitle));
+    dispatch(setTopBarRightLink({ message: message }));
+  }, [dispatch, message]);
 
   if (isOffline && (!group || !message)) {
     return <NotFoundPage reloadOnReconnection={false} isTopBar={false} />;

--- a/agir/msgs/components/MessagePage/MessagePage.js
+++ b/agir/msgs/components/MessagePage/MessagePage.js
@@ -8,7 +8,10 @@ import { useMessageSWR, useMessageActions } from "@agir/msgs/common/hooks";
 import { useCommentsSWR } from "@agir/msgs/common/hooks";
 import { mutate } from "swr";
 import { useDispatch } from "@agir/front/globalContext/GlobalContext";
-import { setPageTitle } from "@agir/front/globalContext/actions";
+import {
+  setPageTitle,
+  setTopBarRightLink,
+} from "@agir/front/globalContext/actions";
 import { getMessageSubject } from "@agir/msgs/common/utils";
 import { useIsOffline } from "@agir/front/offline/hooks";
 import { useInfiniteScroll } from "@agir/lib/utils/hooks";
@@ -109,16 +112,23 @@ const MessagePage = ({ messagePk }) => {
     !isLoadingInitialData && user && typeof messages !== "undefined";
 
   useEffect(() => {
+    const updateCount = async () => {
+      if (!messagePk) {
+        return;
+      }
+      await mutate("/api/user/messages/unread_count/");
+      mutateMessages && mutateMessages();
+    };
+    updateCount();
+  }, [mutateMessages, messagePk]);
+
+  useEffect(() => {
     dispatch(setPageTitle(pageTitle));
   }, [dispatch, pageTitle]);
 
-  useEffect(async () => {
-    if (!messagePk) {
-      return;
-    }
-    await mutate("/api/user/messages/unread_count/");
-    mutateMessages && mutateMessages();
-  }, [messagePk]);
+  useEffect(() => {
+    currentMessage && dispatch(setTopBarRightLink({ message: currentMessage }));
+  }, [dispatch, currentMessage]);
 
   return (
     <>


### PR DESCRIPTION
- Refactor mobile TopBar to avoid calling messages API on each page
- Refactor useCustomAnnouncement to stop api calls after 404 response for the current session