### PR TITLE
feat: add a list of reduced sample rate endpoints for sentry

### DIFF
--- a/agir/api/settings.py
+++ b/agir/api/settings.py
@@ -666,6 +666,13 @@ if not DEBUG:
     }
 
     def sentry_traces_sampler(ctx):
+        reduced_traces_sample_rate_endpoints = [
+            "/api/ping/",
+            "/api/session/",
+            "/api/user/activities/unread-count/",
+            "/api/user/messages/unread_count/",
+            "/nuntius/open/",
+        ]
         default_traces_sample_rate = os.environ.get("SENTRY_DEFAULT_TRACES_SAMPLE_RATE")
         try:
             default_traces_sample_rate = float(default_traces_sample_rate)
@@ -690,8 +697,9 @@ if not DEBUG:
                 # Get the URL for ASGI requests
                 url = ctx["asgi_scope"].get("path", "")
 
-            if url and "/ping/" in url:
-                return 0.01
+            for endpoint in reduced_traces_sample_rate_endpoints:
+                if url and endpoint in url.lower():
+                    return 0.01
 
         return default_traces_sample_rate
 


### PR DESCRIPTION
```
/api/ping/
/api/session/
/api/user/activities/unread-count/
/api/user/messages/unread_count/
/nuntius/open/
```