### PR TITLE
Add last manager login admin field and list filter

### DIFF
--- a/agir/groups/admin/panels.py
+++ b/agir/groups/admin/panels.py
@@ -53,6 +53,7 @@ class SupportGroupAdmin(VersionAdmin, CenterOnFranceMixin, OSMGeoAdmin):
                     "link",
                     "created",
                     "modified",
+                    "last_manager_login",
                     "action_buttons",
                     "promo_code",
                     "allocation",
@@ -137,6 +138,7 @@ class SupportGroupAdmin(VersionAdmin, CenterOnFranceMixin, OSMGeoAdmin):
         "certification_criteria",
         "certification_actions",
         "export_buttons",
+        "last_manager_login",
     )
     date_hierarchy = "created"
 
@@ -166,6 +168,7 @@ class SupportGroupAdmin(VersionAdmin, CenterOnFranceMixin, OSMGeoAdmin):
         "subtypes",
         "tags",
         filters.TooMuchMembersFilter,
+        filters.LastManagerLoginFilter,
     )
 
     search_fields = ("name", "description", "location_city")
@@ -269,6 +272,14 @@ class SupportGroupAdmin(VersionAdmin, CenterOnFranceMixin, OSMGeoAdmin):
             return mark_safe("-")
 
     link.short_description = _("Page sur le site")
+
+    def last_manager_login(self, obj):
+        if not obj:
+            return "-"
+
+        return obj.get_last_manager_login() or "-"
+
+    last_manager_login.short_description = _("Dernière connexion d'un·e gestionnaire")
 
     @admin.display(description="Actions")
     def action_buttons(self, obj):

--- a/agir/groups/models.py
+++ b/agir/groups/models.py
@@ -499,6 +499,14 @@ class SupportGroup(
             absolute=True,
         )
 
+    def get_last_manager_login(self):
+        return (
+            self.memberships.active()
+            .managers()
+            .aggregate(Max("person__role__last_login"))
+            .get("person__role__last_login__max")
+        )
+
     def front_url(self):
         return front_url("view_group", args=(self.pk,), absolute=True)
 

--- a/agir/groups/tests/test_admin.py
+++ b/agir/groups/tests/test_admin.py
@@ -1,8 +1,12 @@
+from dateutil.relativedelta import relativedelta
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 
-from agir.groups.models import SupportGroup, TransferOperation
+from agir.groups import admin
+from agir.groups.admin.filters import LastManagerLoginFilter
+from agir.groups.models import SupportGroup, TransferOperation, Membership
 from agir.people.models import Person
 
 
@@ -48,3 +52,176 @@ class TransferOperationAdmin(TestCase):
             )
         )
         self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+
+class LastManagerLoginFilterTest(TestCase):
+    def setUp(self) -> None:
+        today = timezone.now()
+
+        self.recently_logged_in_group = SupportGroup.objects.create(
+            name="recently_logged_in"
+        )
+        self.recently_logged_in_person = Person.objects.create_person(
+            "today@agir.test", create_role=True
+        )
+        self.recently_logged_in_person.role.last_login = today
+        self.recently_logged_in_person.role.save()
+        Membership.objects.create(
+            person=self.recently_logged_in_person,
+            supportgroup=self.recently_logged_in_group,
+            membership_type=Membership.MEMBERSHIP_TYPE_MANAGER,
+        )
+
+        self.one_month_old_login_group = SupportGroup.objects.create(
+            name="one_month_old_login"
+        )
+        self.one_month_old_login_person = Person.objects.create_person(
+            "one_month@agir.test", create_role=True
+        )
+        self.one_month_old_login_person.role.last_login = today - relativedelta(
+            months=1
+        )
+        self.one_month_old_login_person.role.save()
+        Membership.objects.create(
+            person=self.one_month_old_login_person,
+            supportgroup=self.one_month_old_login_group,
+            membership_type=Membership.MEMBERSHIP_TYPE_MANAGER,
+        )
+
+        self.two_month_old_login_group = SupportGroup.objects.create(
+            name="two_mont_old_login"
+        )
+        self.two_month_old_login_person = Person.objects.create_person(
+            "two_month@agir.test", create_role=True
+        )
+        self.two_month_old_login_person.role.last_login = today - relativedelta(
+            months=2
+        )
+        self.two_month_old_login_person.role.save()
+        Membership.objects.create(
+            person=self.two_month_old_login_person,
+            supportgroup=self.two_month_old_login_group,
+            membership_type=Membership.MEMBERSHIP_TYPE_MANAGER,
+        )
+
+        self.not_yet_logged_in_group = SupportGroup.objects.create(
+            name="not_yet_logged_in"
+        )
+        self.not_yet_logged_in_person = Person.objects.create_person(
+            "never@agir.test", create_role=False
+        )
+        Membership.objects.create(
+            person=self.not_yet_logged_in_person,
+            supportgroup=self.not_yet_logged_in_group,
+            membership_type=Membership.MEMBERSHIP_TYPE_MANAGER,
+        )
+
+    def test_test_data_is_ok(self):
+        self.assertEqual(
+            self.recently_logged_in_person.role.last_login,
+            self.recently_logged_in_group.get_last_manager_login(),
+        )
+        self.assertEqual(
+            self.one_month_old_login_person.role.last_login,
+            self.one_month_old_login_group.get_last_manager_login(),
+        )
+        self.assertEqual(
+            self.two_month_old_login_person.role.last_login,
+            self.two_month_old_login_group.get_last_manager_login(),
+        )
+        self.assertIsNone(self.not_yet_logged_in_group.get_last_manager_login())
+
+    def test_empty_filter(self):
+        f = LastManagerLoginFilter(
+            None,
+            {"last_manager_login": None},
+            SupportGroup,
+            admin.SupportGroupAdmin,
+        )
+        filtered_qs = f.queryset(None, SupportGroup.objects.all())
+        self.assertIn(self.recently_logged_in_group, filtered_qs)
+        self.assertIn(self.one_month_old_login_group, filtered_qs)
+        self.assertIn(self.two_month_old_login_group, filtered_qs)
+        self.assertIn(self.not_yet_logged_in_group, filtered_qs)
+
+    def test_invalid_filter(self):
+        f = LastManagerLoginFilter(
+            None,
+            {"last_manager_login": "2_months_from_now"},
+            SupportGroup,
+            admin.SupportGroupAdmin,
+        )
+        filtered_qs = f.queryset(None, SupportGroup.objects.all())
+        self.assertIn(self.recently_logged_in_group, filtered_qs)
+        self.assertIn(self.one_month_old_login_group, filtered_qs)
+        self.assertIn(self.two_month_old_login_group, filtered_qs)
+        self.assertIn(self.not_yet_logged_in_group, filtered_qs)
+
+    def test_one_week_ago_filter(self):
+        f = LastManagerLoginFilter(
+            None,
+            {"last_manager_login": "1_week_ago"},
+            SupportGroup,
+            admin.SupportGroupAdmin,
+        )
+        filtered_qs = f.queryset(None, SupportGroup.objects.all())
+        self.assertNotIn(self.recently_logged_in_group, filtered_qs)
+        self.assertIn(self.one_month_old_login_group, filtered_qs)
+        self.assertIn(self.two_month_old_login_group, filtered_qs)
+        self.assertIn(self.not_yet_logged_in_group, filtered_qs)
+
+    def test_one_month_ago_filter(self):
+        f = LastManagerLoginFilter(
+            None,
+            {"last_manager_login": "1_month_ago"},
+            SupportGroup,
+            admin.SupportGroupAdmin,
+        )
+        filtered_qs = f.queryset(None, SupportGroup.objects.all())
+        self.assertNotIn(self.recently_logged_in_group, filtered_qs)
+        self.assertIn(self.one_month_old_login_group, filtered_qs)
+        self.assertIn(self.two_month_old_login_group, filtered_qs)
+        self.assertIn(self.not_yet_logged_in_group, filtered_qs)
+
+    def test_two_month_ago_filter(self):
+        f = LastManagerLoginFilter(
+            None,
+            {"last_manager_login": "2_month_ago"},
+            SupportGroup,
+            admin.SupportGroupAdmin,
+        )
+        filtered_qs = f.queryset(None, SupportGroup.objects.all())
+        self.assertNotIn(self.recently_logged_in_group, filtered_qs)
+        self.assertNotIn(self.one_month_old_login_group, filtered_qs)
+        self.assertIn(self.two_month_old_login_group, filtered_qs)
+        self.assertIn(self.not_yet_logged_in_group, filtered_qs)
+
+    def test_three_month_ago_filter(self):
+        f = LastManagerLoginFilter(
+            None,
+            {"last_manager_login": "3_month_ago"},
+            SupportGroup,
+            admin.SupportGroupAdmin,
+        )
+        filtered_qs = f.queryset(None, SupportGroup.objects.all())
+        self.assertNotIn(self.recently_logged_in_group, filtered_qs)
+        self.assertNotIn(self.one_month_old_login_group, filtered_qs)
+        self.assertNotIn(self.two_month_old_login_group, filtered_qs)
+        self.assertIn(self.not_yet_logged_in_group, filtered_qs)
+
+    def test_exact_date_ago_filter(self):
+        f = LastManagerLoginFilter(
+            None,
+            {
+                "last_manager_login": (timezone.now() - relativedelta(days=36))
+                .date()
+                .strftime("%Y-%m-%d")
+            },
+            SupportGroup,
+            admin.SupportGroupAdmin,
+        )
+        filtered_qs = f.queryset(None, SupportGroup.objects.all())
+        self.assertNotIn(self.recently_logged_in_group, filtered_qs)
+        self.assertNotIn(self.one_month_old_login_group, filtered_qs)
+        self.assertIn(self.two_month_old_login_group, filtered_qs)
+        self.assertIn(self.not_yet_logged_in_group, filtered_qs)


### PR DESCRIPTION
- Ajout d'un filtre dans l'admin des groupes d'action pour pouvoir voir ceux dont les gestionnaires ne se sont pas connecté·es à la plateforme depuis un certain temps.
- Ajout d'une méthode au modèle `SupportGroup` pour récupérer la dernière date de connexion des gestionnaires
