### PR TITLE
fix: les tâches Celery toujours executées hors connexion

### DIFF
--- a/agir/cagnottes/views.py
+++ b/agir/cagnottes/views.py
@@ -88,7 +88,7 @@ def notification_listener(payment):
             # adresse email. On récupère la personne associée à cette adresse email, ou on la crée, et on l'associe à
             # ce paiement.
             find_or_create_person_from_payment(payment)
-            transaction.on_commit(partial(envoyer_email_remerciement.delay, payment.pk))
+            envoyer_email_remerciement.delay(payment.pk)
             transaction.on_commit(partial(incrementer_compteur, payment))
 
     if payment.status == Payment.STATUS_REFUND:

--- a/agir/donations/admin/actions.py
+++ b/agir/donations/admin/actions.py
@@ -193,14 +193,11 @@ def save_spending_request_admin_review(
         spending_request.bank_transfer_label = bank_transfer_label
         spending_request.save()
 
-        transaction.on_commit(
-            partial(
-                spending_request_notify_group_managers.delay,
-                spending_request.pk,
-                to_status=to_status,
-                from_status=from_status,
-                comment=comment,
-            )
+        spending_request_notify_group_managers.delay(
+            spending_request.pk,
+            to_status=to_status,
+            from_status=from_status,
+            comment=comment,
         )
 
 

--- a/agir/donations/spending_requests.py
+++ b/agir/donations/spending_requests.py
@@ -279,14 +279,11 @@ def validate_action(spending_request, user):
                 destination=SPENDING_ACCOUNT,
             )
 
-        transaction.on_commit(
-            partial(
-                schedule_validation_notifications,
-                spending_request,
-                to_status=next_status,
-                from_status=current_status,
-                user=user,
-            )
+        schedule_validation_notifications(
+            spending_request,
+            to_status=next_status,
+            from_status=current_status,
+            user=user,
         )
 
         return True

--- a/agir/donations/views/donations_views.py
+++ b/agir/donations/views/donations_views.py
@@ -319,11 +319,7 @@ class ReturnView(TemplateView):
 
 def subscription_notification_listener(subscription):
     if subscription.status == Subscription.STATUS_ACTIVE:
-        transaction.on_commit(
-            partial(
-                send_donation_email.delay, subscription.person.pk, subscription.type
-            )
-        )
+        send_donation_email.delay(subscription.person.pk, subscription.type)
 
 
 def notification_listener(payment):
@@ -336,9 +332,7 @@ def notification_listener(payment):
             apply_payment_allocations(payment)
 
             if payment.subscription is None:
-                transaction.on_commit(
-                    partial(send_donation_email.delay, payment.person.pk, payment.type)
-                )
+                send_donation_email.delay(payment.person.pk, payment.type)
 
     if payment.status == Payment.STATUS_REFUND:
         cancel_payment_allocations(payment)

--- a/agir/elections/actions.py
+++ b/agir/elections/actions.py
@@ -57,14 +57,12 @@ def create_or_update_polling_station_officer(data):
             person_id=person.pk, defaults={**data, "contact_email": email}
         )
 
-        transaction.on_commit(partial(geocode_person.delay, person.pk))
+        geocode_person.delay(person.pk)
 
         if is_new_person and "welcome" in SUBSCRIPTIONS_EMAILS[SUBSCRIPTION_TYPE_AP]:
             from agir.people.tasks import send_welcome_mail
 
-            transaction.on_commit(
-                partial(send_welcome_mail.delay, person.pk, SUBSCRIPTION_TYPE_AP)
-            )
+            send_welcome_mail.delay(person.pk, SUBSCRIPTION_TYPE_AP)
 
         data.update(
             {

--- a/agir/event_requests/actions.py
+++ b/agir/event_requests/actions.py
@@ -270,7 +270,7 @@ def accept_event_request(event_request):
         event_request.save()
 
         # Schedule post-creation tasks
-        transaction.on_commit(partial(schedule_new_event_tasks, event_request))
+        schedule_new_event_tasks(event_request)
 
 
 def accept_event_speaker_request(event_speaker_request):

--- a/agir/events/actions/rsvps.py
+++ b/agir/events/actions/rsvps.py
@@ -139,7 +139,7 @@ def rsvp_to_free_event(event, person, form_submission=None):
         with transaction.atomic():
             rsvp = _get_rsvp_for_event(event, person, form_submission, False)
             rsvp.save()
-            transaction.on_commit(partial(send_rsvp_notification.delay, rsvp.pk))
+            send_rsvp_notification.delay(rsvp.pk)
     except IntegrityError:
         pass
 
@@ -251,7 +251,7 @@ def validate_payment_for_rsvp(payment):
 
     # on programme l'envoi de la notification à la fin de la transaction, pour s'assurer que
     # la tâche Celery s'exécute bien après la fin de la transaction (et voit donc le RSVP mis à jour)
-    transaction.on_commit(partial(send_rsvp_notification.delay, rsvp.pk))
+    send_rsvp_notification.delay(rsvp.pk)
     return rsvp
 
 
@@ -401,7 +401,7 @@ def validate_payment_for_guest(payment):
     guest.save()
 
     # à faire au commit uniquement
-    transaction.on_commit(partial(send_guest_confirmation.delay, guest.rsvp_id))
+    send_guest_confirmation.delay(guest.rsvp_id)
 
     return guest
 

--- a/agir/events/serializers.py
+++ b/agir/events/serializers.py
@@ -1135,14 +1135,11 @@ class UpdateEventSerializer(serializers.ModelSerializer):
                 ):
                     Projet.objects.from_event(event, event.organizers.first().role)
 
-            transaction.on_commit(
-                partial(
-                    self.schedule_tasks,
-                    event,
-                    changed_data_fields,
-                    changed_supportgroup,
-                    has_new_report,
-                )
+            self.schedule_tasks(
+                event,
+                changed_data_fields,
+                changed_supportgroup,
+                has_new_report,
             )
             return event
 

--- a/agir/events/signals.py
+++ b/agir/events/signals.py
@@ -28,7 +28,7 @@ def copier_participant_feuille_externe(instance, sheet):
     if not task:
         return
 
-    transaction.on_commit(partial(task, instance.pk))
+    task.delay(instance.pk)
 
 
 @receiver(post_save, sender=RSVP, dispatch_uid="copier_rsvp_feuille_externe")

--- a/agir/groups/actions/notifications.py
+++ b/agir/groups/actions/notifications.py
@@ -87,15 +87,12 @@ def someone_joined_notification(membership, membership_count=1):
             # 30, (disabled until further notice)
         ]
     ):
-        transaction.on_commit(
-            partial(
-                send_alert_capacity_email.delay,
-                membership.supportgroup.pk,
-                membership_count,
-            )
+        send_alert_capacity_email.delay(
+            membership.supportgroup.pk,
+            membership_count,
         )
 
-    transaction.on_commit(partial(send_joined_notification_email.delay, membership.pk))
+    send_joined_notification_email.delay(membership.pk)
 
 
 @transaction.atomic()
@@ -125,7 +122,7 @@ def new_message_notifications(message):
         send_post_save_signal=True,
     )
 
-    transaction.on_commit(partial(send_message_notification_email.delay, message.pk))
+    send_message_notification_email.delay(message.pk)
 
 
 # Group comment with required membership type

--- a/agir/groups/forms.py
+++ b/agir/groups/forms.py
@@ -363,11 +363,8 @@ class TransferGroupMembersForm(forms.Form):
             Membership.objects.bulk_create(new_memberships, ignore_conflicts=True)
             memberships.delete()
 
-            transaction.on_commit(
-                partial(
-                    schedule_membership_transfer_tasks,
-                    transfer_operation,
-                )
+            schedule_membership_transfer_tasks(
+                transfer_operation,
             )
 
         return {

--- a/agir/lib/celery.py
+++ b/agir/lib/celery.py
@@ -4,10 +4,9 @@ from functools import wraps
 
 import requests
 from celery import shared_task
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from push_notifications.gcm import GCMError
-
-from django.conf import settings
 
 TASK_PRIORITY_LOW = settings.CELERY_TASK_PRIORITY_LOW
 TASK_PRIORITY_NORMAL = settings.CELERY_TASK_PRIORITY_NORMAL

--- a/agir/loans/tests.py
+++ b/agir/loans/tests.py
@@ -92,8 +92,8 @@ class LoansTestCase(TransactionTestCase):
         return req
 
     @using_separate_redis_server
-    @patch("django.db.transaction.on_commit")
-    def test_can_make_a_loan_when_logged_in(self, on_commit):
+    @patch("agir.loans.views.generate_and_send_contract")
+    def test_can_make_a_loan_when_logged_in(self, generate_and_send_contract):
         self.factory.user = self.p1.role
         self.factory.session = {}
 
@@ -145,8 +145,5 @@ class LoansTestCase(TransactionTestCase):
 
         loan_notification_listener(payment)
 
-        on_commit.assert_called_once()
-        partial = on_commit.call_args[0][0]
-
-        self.assertEqual(partial.func, generate_and_send_contract)
-        self.assertEqual(partial.args, (payment.id,))
+        generate_and_send_contract.assert_called_once()
+        self.assertEqual(generate_and_send_contract.call_args[0], (payment.id,))

--- a/agir/loans/views.py
+++ b/agir/loans/views.py
@@ -202,4 +202,4 @@ def generate_and_send_contract(payment_id):
 def loan_notification_listener(payment):
     if payment.status == Payment.STATUS_COMPLETED:
         find_or_create_person_from_payment(payment)
-        transaction.on_commit(partial(generate_and_send_contract, payment.id))
+        generate_and_send_contract(payment.id)

--- a/agir/notifications/signals.py
+++ b/agir/notifications/signals.py
@@ -44,12 +44,9 @@ def push_new_activity(sender, instance, created=False, **kwargs):
     ]
 
     for apns_device_pk in apns_device_pks:
-        transaction.on_commit(
-            partial(
-                send_apns_activity.delay,
-                instance.pk,
-                apns_device_pk,
-            )
+        send_apns_activity.delay(
+            instance.pk,
+            apns_device_pk,
         )
 
     # SEND FCM NOTIFICATIONS
@@ -61,12 +58,9 @@ def push_new_activity(sender, instance, created=False, **kwargs):
     ]
 
     for fcm_device_pk in fcm_device_pks:
-        transaction.on_commit(
-            partial(
-                send_fcm_activity.delay,
-                instance.pk,
-                fcm_device_pk,
-            )
+        send_fcm_activity.delay(
+            instance.pk,
+            fcm_device_pk,
         )
 
 

--- a/agir/people/actions/subscription.py
+++ b/agir/people/actions/subscription.py
@@ -171,13 +171,10 @@ def save_subscription_information(person, type, data, new=False):
                 # l'import se fait ici pour éviter les imports circulaires
                 from ..tasks import notify_referrer
 
-                transaction.on_commit(
-                    partial(
-                        notify_referrer.delay,
-                        referrer_id=str(referrer.id),
-                        referred_id=str(person.id),
-                        referral_type=type,
-                    )
+                notify_referrer.delay(
+                    referrer_id=str(referrer.id),
+                    referred_id=str(person.id),
+                    referral_type=type,
                 )
 
     # on fusionne les éventuelles metadata
@@ -279,9 +276,7 @@ def save_contact_information(data):
 
         from agir.people.tasks import notify_contact
 
-        transaction.on_commit(
-            partial(notify_contact.delay, str(person.id), is_new=is_new)
-        )
+        notify_contact.delay(str(person.id), is_new=is_new)
 
     if tags and is_new:
         person.tags.add(*tags)

--- a/agir/people/forms/profile.py
+++ b/agir/people/forms/profile.py
@@ -172,7 +172,7 @@ class PersonalInformationsForm(ImageFormMixin, forms.ModelForm):
         if not self.instance.should_relocate_when_address_changed():
             return
         if any(field in self.changed_data for field in self.instance.GEOCODING_FIELDS):
-            transaction.on_commit(partial(geocode_person.delay, self.instance.pk))
+            geocode_person.delay(self.instance.pk)
 
     class Meta:
         model = Person

--- a/agir/people/serializers.py
+++ b/agir/people/serializers.py
@@ -369,7 +369,7 @@ class PersonSerializer(FlexibleFieldsMixin, serializers.ModelSerializer):
     def update(self, instance, validated_data):
         instance = super().update(instance, validated_data)
         if any(field in validated_data for field in instance.GEOCODING_FIELDS):
-            transaction.on_commit(partial(geocode_person.delay, instance.pk))
+            geocode_person.delay(instance.pk)
         return instance
 
     class Meta:

--- a/agir/polls/views.py
+++ b/agir/polls/views.py
@@ -137,9 +137,7 @@ class PollParticipationView(
             return HttpResponseRedirect(self.get_success_url())
 
         if self.object.rules.get("confirmation_email", True):
-            transaction.on_commit(
-                partial(send_vote_confirmation_email.delay, choice.id)
-            )
+            send_vote_confirmation_email.delay(choice.id)
 
         messages.add_message(
             self.request,

--- a/agir/voting_proxies/actions.py
+++ b/agir/voting_proxies/actions.py
@@ -221,11 +221,8 @@ def accept_single_voting_proxy_request(voting_proxy, voting_proxy_request):
         voting_proxy.status = VotingProxy.STATUS_AVAILABLE
         voting_proxy.save()
 
-    transaction.on_commit(
-        partial(
-            send_voting_proxy_request_accepted_text_messages.delay,
-            [voting_proxy_request.pk],
-        )
+    send_voting_proxy_request_accepted_text_messages.delay(
+        [voting_proxy_request.pk],
     )
 
 
@@ -238,11 +235,8 @@ def accept_voting_proxy_requests(voting_proxy, voting_proxy_requests):
         voting_proxy.status = VotingProxy.STATUS_AVAILABLE
         voting_proxy.save()
 
-    transaction.on_commit(
-        partial(
-            send_voting_proxy_request_accepted_text_messages.delay,
-            list(voting_proxy_requests.values_list("pk", flat=True)),
-        )
+    send_voting_proxy_request_accepted_text_messages.delay(
+        list(voting_proxy_requests.values_list("pk", flat=True)),
     )
 
 


### PR DESCRIPTION
Cette PR crée une nouvelle classe de base pour les tâches Celery qui redéfinit `apply_async` pour toujours s'exécuter avec `transaction.on_commit`, donc au plus tôt à la fin de la transaction courante.

Cela permettra à l'avenir d'éviter d'avoir à se souvenir d'utiliser `on_commit` pour les tâches celery.